### PR TITLE
Add navs and navbar

### DIFF
--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -27,6 +27,7 @@ import {
   ListGroupItem,
   ListGroupItemHeading,
   ListGroupItemText,
+  Navbar,
   Popover,
   PopoverBody,
   PopoverHeader,
@@ -118,222 +119,226 @@ class PopoverComponent extends Component {
 
 class Demo extends Component {
   render() {
-    return (<Container>
-      <h1>Dash Bootstrap Components</h1>
-      <h2>Alerts</h2>
-      <div>
-        <Alert color="primary">
-          This is a primary alert
-        </Alert>
-        <Alert color="secondary">
-          This is a secondary alert
-        </Alert>
-        <Alert color="success">
-          This is a success alert
-        </Alert>
-        <Alert color="danger">
-          This is a danger alert
-        </Alert>
-        <Alert color="warning">
-          This is a warning alert
-        </Alert>
-        <Alert color="info">
-          This is a info alert
-        </Alert>
-        <Alert color="light">
-          This is a light alert
-        </Alert>
-        <Alert color="dark">
-          This is a dark alert
-        </Alert>
-      </div>
+    return (<React.Fragment>
+      <Navbar fixed="top" brand="Dash Bootstrap Components" brandHref="https://github.com/ASIDataScience/dash-bootstrap-components">
+        TODO
+      </Navbar>
+      <Container>
+        <h1>Dash Bootstrap Components</h1>
+        <h2>Alerts</h2>
+        <div>
+          <Alert color="primary">
+            This is a primary alert
+          </Alert>
+          <Alert color="secondary">
+            This is a secondary alert
+          </Alert>
+          <Alert color="success">
+            This is a success alert
+          </Alert>
+          <Alert color="danger">
+            This is a danger alert
+          </Alert>
+          <Alert color="warning">
+            This is a warning alert
+          </Alert>
+          <Alert color="info">
+            This is a info alert
+          </Alert>
+          <Alert color="light">
+            This is a light alert
+          </Alert>
+          <Alert color="dark">
+            This is a dark alert
+          </Alert>
+        </div>
 
-      <br/>
+        <br/>
 
-      <h2>Badges</h2>
-      <h4>{"A heading with a badge "}
-        <Badge color="primary">New!</Badge>
-      </h4>
-      <p>{"Do you take the "}
-        <Badge pill={true} color="danger">red pill</Badge>
-        {" or the "}
-        <Badge pill={true} color="primary">blue pill</Badge>
-      </p>
+        <h2>Badges</h2>
+        <h4>{"A heading with a badge "}
+          <Badge color="primary">New!</Badge>
+        </h4>
+        <p>{"Do you take the "}
+          <Badge pill={true} color="danger">red pill</Badge>
+          {" or the "}
+          <Badge pill={true} color="primary">blue pill</Badge>
+        </p>
 
-      <br/>
+        <br/>
 
-      <h2>Buttons</h2>
-      <div>
-        <Button color="primary">primary</Button>{' '}
-        <Button color="secondary">secondary</Button>{' '}
-        <Button color="success">success</Button>{' '}
-        <Button color="info">info</Button>{' '}
-        <Button color="warning">warning</Button>{' '}
-        <Button color="danger">danger</Button>{' '}
-        <Button color="link">link</Button>
-      </div>
-      <br/>
-      <h4>Outline buttons</h4>
-      <div>
-        <Button outline={true} color="primary">primary</Button>{' '}
-        <Button outline={true} color="secondary">secondary</Button>{' '}
-        <Button outline={true} color="success">success</Button>{' '}
-        <Button outline={true} color="info">info</Button>{' '}
-        <Button outline={true} color="warning">warning</Button>{' '}
-        <Button outline={true} color="danger">danger</Button>{' '}
-        <Button outline={true} color="link">link</Button>
-      </div>
-      <br/>
-      <h4>Block button</h4>
-      <div>
-        <Button block={true} color="primary">primary block</Button>{' '}
-      </div>
-      <h4>Button Group</h4>
-      <div>
-        <ButtonGroup size="sm">
-          <Button color="danger">Left</Button>
-          <Button color="warning">Middle</Button>
-          <Button color="success">Right</Button>
-        </ButtonGroup>
-      </div>
+        <h2>Buttons</h2>
+        <div>
+          <Button color="primary">primary</Button>{' '}
+          <Button color="secondary">secondary</Button>{' '}
+          <Button color="success">success</Button>{' '}
+          <Button color="info">info</Button>{' '}
+          <Button color="warning">warning</Button>{' '}
+          <Button color="danger">danger</Button>{' '}
+          <Button color="link">link</Button>
+        </div>
+        <br/>
+        <h4>Outline buttons</h4>
+        <div>
+          <Button outline={true} color="primary">primary</Button>{' '}
+          <Button outline={true} color="secondary">secondary</Button>{' '}
+          <Button outline={true} color="success">success</Button>{' '}
+          <Button outline={true} color="info">info</Button>{' '}
+          <Button outline={true} color="warning">warning</Button>{' '}
+          <Button outline={true} color="danger">danger</Button>{' '}
+          <Button outline={true} color="link">link</Button>
+        </div>
+        <br/>
+        <h4>Block button</h4>
+        <div>
+          <Button block={true} color="primary">primary block</Button>{' '}
+        </div>
+        <h4>Button Group</h4>
+        <div>
+          <ButtonGroup size="sm">
+            <Button color="danger">Left</Button>
+            <Button color="warning">Middle</Button>
+            <Button color="success">Right</Button>
+          </ButtonGroup>
+        </div>
 
-      <br/>
+        <br/>
 
-      <h2>Cards</h2>
+        <h2>Cards</h2>
 
-      <Row>
-        <Col md={3}>
-          <Card color="dark" outline={true}>
-            <CardHeader>Header</CardHeader>
-            <CardBody>
-              <CardTitle>This card has a header</CardTitle>
-              <CardText>And some text in the body</CardText>
-            </CardBody>
-          </Card>
-        </Col>
-        <Col md={3}>
+        <Row>
+          <Col md={3}>
+            <Card color="dark" outline={true}>
+              <CardHeader>Header</CardHeader>
+              <CardBody>
+                <CardTitle>This card has a header</CardTitle>
+                <CardText>And some text in the body</CardText>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col md={3}>
+            <Card>
+              <CardImg top={true} src="https://images.pexels.com/photos/457882/pexels-photo-457882.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=350"/>
+              <CardBody>
+                <CardTitle>Card with image</CardTitle>
+                <CardText>This card has an image</CardText>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col md={3}>
+            <Card>
+              <CardBody>
+                <CardTitle>Here's another card</CardTitle>
+                <CardText>With some text, and a button</CardText>
+                <Button color="success">Click here</Button>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col md={3}>
+            <Card>
+              <CardBody>
+                <CardTitle>Here's yet another card</CardTitle>
+                <CardText>With some text, and some links</CardText>
+                <CardLink href="https://www.asidatascience.com">External</CardLink>
+                <CardLink href="/example">Internal</CardLink>
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+
+        <h4>Card deck</h4>
+        <CardDeck>
           <Card>
-            <CardImg top={true} src="https://images.pexels.com/photos/457882/pexels-photo-457882.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=350"/>
             <CardBody>
-              <CardTitle>Card with image</CardTitle>
-              <CardText>This card has an image</CardText>
+              <CardTitle>The first card</CardTitle>
+              <CardText>
+                This is a card with some text on it, it's the first one in the deck.
+              </CardText>
             </CardBody>
           </Card>
-        </Col>
-        <Col md={3}>
           <Card>
             <CardBody>
-              <CardTitle>Here's another card</CardTitle>
-              <CardText>With some text, and a button</CardText>
-              <Button color="success">Click here</Button>
+              <CardTitle>The second card</CardTitle>
+              <CardText>
+                This is a card with some text on it, it's the second one in the deck. It has a bit more text in it so that we can see how the vertical spacing will work.
+              </CardText>
             </CardBody>
           </Card>
-        </Col>
-        <Col md={3}>
+          <Card outline={true} color="primary">
+            <CardBody>
+              <CardTitle>The third card</CardTitle>
+              <CardSubtitle>...and the last :(</CardSubtitle>
+              <CardText>
+                This card doesn't have much text...
+              </CardText>
+              <Button color="danger">Click me</Button>
+            </CardBody>
+          </Card>
+        </CardDeck>
+
+        <br/>
+
+        <h2>Collapse</h2>
+        <CollapseComponent>
           <Card>
             <CardBody>
-              <CardTitle>Here's yet another card</CardTitle>
-              <CardText>With some text, and some links</CardText>
-              <CardLink href="https://www.asidatascience.com">External</CardLink>
-              <CardLink href="/example">Internal</CardLink>
+              This content is hidable in the collapse element.
             </CardBody>
           </Card>
-        </Col>
-      </Row>
+        </CollapseComponent>
 
-      <h4>Card deck</h4>
-      <CardDeck>
-        <Card>
-          <CardBody>
-            <CardTitle>The first card</CardTitle>
-            <CardText>
-              This is a card with some text on it, it's the first one in the deck.
-            </CardText>
-          </CardBody>
-        </Card>
-        <Card>
-          <CardBody>
-            <CardTitle>The second card</CardTitle>
-            <CardText>
-              This is a card with some text on it, it's the second one in the deck. It has a bit more text in it so that we can see how the vertical spacing will work.
-            </CardText>
-          </CardBody>
-        </Card>
-        <Card outline={true} color="primary">
-          <CardBody>
-            <CardTitle>The third card</CardTitle>
-            <CardSubtitle>...and the last :(</CardSubtitle>
-            <CardText>
-              This card doesn't have much text...
-            </CardText>
-            <Button color="danger">Click me</Button>
-          </CardBody>
-        </Card>
-      </CardDeck>
+        <br/>
 
-      <br/>
-
-      <h2>Collapse</h2>
-      <CollapseComponent>
-        <Card>
-          <CardBody>
-            This content is hidable in the collapse element.
-          </CardBody>
-        </Card>
-      </CollapseComponent>
-
-      <br/>
-
-      <h2>Columns</h2>
-      <Row>
-        <Col md={3}>
-          <div style={{
+        <h2>Columns</h2>
+        <Row>
+          <Col md={3}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
-            <h4>A quarter width column</h4>
-          </div>
-        </Col>
-        <Col md={6}>
-          <div style={{
+              <h4>A quarter width column</h4>
+            </div>
+          </Col>
+          <Col md={6}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
-            <h4>A half width column</h4>
-            <p>With some text below</p>
-          </div>
-        </Col>
-        <Col md={3}>
-          <div style={{
+              <h4>A half width column</h4>
+              <p>With some text below</p>
+            </div>
+          </Col>
+          <Col md={3}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
-            <h4>A quarter width column</h4>
-          </div>
-        </Col>
-      </Row>
+              <h4>A quarter width column</h4>
+            </div>
+          </Col>
+        </Row>
 
-      <h4>Row with no gutters</h4>
-      <Row noGutters={true}>
-        <Col md={3}>
-          <div style={{
+        <h4>Row with no gutters</h4>
+        <Row noGutters={true}>
+          <Col md={3}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
-            <h4>A quarter width column</h4>
-          </div>
-        </Col>
-        <Col md={6}>
-          <div style={{
+              <h4>A quarter width column</h4>
+            </div>
+          </Col>
+          <Col md={6}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
-            <h4>A half width column</h4>
-            <p>With some text below</p>
-          </div>
-        </Col>
-        <Col md={3}>
-          <div style={{
+              <h4>A half width column</h4>
+              <p>With some text below</p>
+            </div>
+          </Col>
+          <Col md={3}>
+            <div style={{
               borderStyle: "solid",
               padding: "10px"
             }}>
@@ -446,7 +451,8 @@ class Demo extends Component {
       <div style={{
           'height' : '200px'
         }}/>
-    </Container>);
+      </Container>
+      </React.Fragment>);
   }
 }
 

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -122,7 +122,7 @@ class PopoverComponent extends Component {
 class Demo extends Component {
   render() {
     return (<React.Fragment>
-      <Navbar fixed="top" brand="Dash Bootstrap Components" brandHref="https://github.com/ASIDataScience/dash-bootstrap-components">
+      <Navbar fixed="top" brand="Dash Bootstrap Components" brand_href="https://github.com/ASIDataScience/dash-bootstrap-components">
         <NavItem>
           <NavLink href="https://www.asidatascience.com">A link</NavLink>
         </NavItem>

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -122,7 +122,7 @@ class PopoverComponent extends Component {
 class Demo extends Component {
   render() {
     return (<React.Fragment>
-      <Navbar fixed="top" brand="Dash Bootstrap Components" brand_href="https://github.com/ASIDataScience/dash-bootstrap-components">
+      <Navbar sticky="top" brand="Dash Bootstrap Components" brand_href="https://github.com/ASIDataScience/dash-bootstrap-components">
         <NavItem>
           <NavLink href="https://www.asidatascience.com">A link</NavLink>
         </NavItem>

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -126,6 +126,12 @@ class Demo extends Component {
         <NavItem>
           <NavLink href="https://www.asidatascience.com">A link</NavLink>
         </NavItem>
+        <Dropdown nav inNavbar label="Menu">
+          <DropdownItem>Entry 1</DropdownItem>
+          <DropdownItem>Entry 2</DropdownItem>
+          <DropdownItem divider />
+          <DropdownItem>Entry 3</DropdownItem>
+        </Dropdown>
       </Navbar>
       <Container>
         <h1>Dash Bootstrap Components</h1>

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -123,7 +123,9 @@ class Demo extends Component {
   render() {
     return (<React.Fragment>
       <Navbar fixed="top" brand="Dash Bootstrap Components" brandHref="https://github.com/ASIDataScience/dash-bootstrap-components">
-        <NavItem><NavLink href="https://www.asidatascience.com">A link</NavLink></NavItem>
+        <NavItem>
+          <NavLink href="https://www.asidatascience.com">A link</NavLink>
+        </NavItem>
       </Navbar>
       <Container>
         <h1>Dash Bootstrap Components</h1>

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -28,6 +28,8 @@ import {
   ListGroupItemHeading,
   ListGroupItemText,
   Navbar,
+  NavItem,
+  NavLink,
   Popover,
   PopoverBody,
   PopoverHeader,
@@ -121,7 +123,7 @@ class Demo extends Component {
   render() {
     return (<React.Fragment>
       <Navbar fixed="top" brand="Dash Bootstrap Components" brandHref="https://github.com/ASIDataScience/dash-bootstrap-components">
-        TODO
+        <NavItem><NavLink href="https://www.asidatascience.com">A link</NavLink></NavItem>
       </Navbar>
       <Container>
         <h1>Dash Bootstrap Components</h1>

--- a/examples/app.py
+++ b/examples/app.py
@@ -6,6 +6,27 @@ from dash.dependencies import Input, Output, State
 
 app = dash.Dash()
 
+
+navbar = dbc.Navbar(
+    brand="Dash Bootstrap components",
+    brand_href="https://github.com/ASIDataScience/dash-bootstrap-components",
+    sticky="top",
+    children=[
+        dbc.NavItem(dbc.NavLink("ASI", href="https://www.asidatascience.com")),
+        dbc.Dropdown(
+            nav=True,
+            inNavbar=True,
+            label="Menu",
+            children=[
+                dbc.DropdownItem("Entry 1"),
+                dbc.DropdownItem("Entry 2"),
+                dbc.DropdownItem(divider=True),
+                dbc.DropdownItem("Entry 3"),
+            ]
+        )
+    ]
+)
+
 header = html.Div(
     [
         html.H1("Dash Bootstrap Components"),
@@ -389,8 +410,9 @@ tooltip = html.Div(
     ]
 )
 
-app.layout = dbc.Container(
-    [
+app.layout = html.Div([
+    navbar,
+    dbc.Container([
         dcc.Interval(id="interval", interval=500, n_intervals=0),
         header,
         html.Br(),
@@ -424,8 +446,8 @@ app.layout = dbc.Container(
         html.Br(),
         tooltip,
         html.Div(style={"height": "200px"}),
-    ]
-)
+    ])
+])
 
 
 @app.callback(

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -45,19 +45,20 @@ Nav.propTypes = {
   pills: PropTypes.bool,
 
   /**
-   * ...
+   * Apply Card styling to nav items
    */
   card: PropTypes.bool,
 
   /**
-   * ...
-   */
-  justified: PropTypes.bool,
-
-  /**
-   * ...
+   * Expand the nav items to fill the entire space available
    */
   fill: PropTypes.bool,
+
+  /**
+   * Expand the nav items to fill the entire space available, making sure
+   * every nav item has the same width.
+   */
+  justified: PropTypes.bool,
 
   /**
    * Arrange NavItems vertically
@@ -65,7 +66,7 @@ Nav.propTypes = {
   vertical: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
-   * ...
+   * Arrange NavItems horizontally
    */
   horizontal: PropTypes.string,
 

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,0 +1,78 @@
+import PropTypes from 'prop-types';
+import {Nav as RSNav} from 'reactstrap';
+
+const Nav = props => {
+  const {
+    children,
+    ...otherProps
+  } = props;
+  return (<RSNav {...otherProps}>
+    {children}
+  </RSNav>);
+}
+
+Nav.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Apply Tab styling to nav items
+   */
+  tabs: PropTypes.bool,
+
+  /**
+   * Apply Pill styling to nav items
+   */
+  pills: PropTypes.bool,
+
+  /**
+   * ...
+   */
+  card: PropTypes.bool,
+
+  /**
+   * ...
+   */
+  justified: PropTypes.bool,
+
+  /**
+   * ...
+   */
+  fill: PropTypes.bool,
+
+  /**
+   * Arrange NavItems vertically
+   */
+  vertical: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+
+  /**
+   * ...
+   */
+  horizontal: PropTypes.string,
+
+  /**
+   * Set to true if using Nav in Navbar component.
+   */
+  navbar: PropTypes.bool
+}
+
+export default Nav;

--- a/src/components/nav/NavItem.js
+++ b/src/components/nav/NavItem.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import { NavItem as RSNavItem } from 'reactstrap';
+
+const NavItem = props => {
+  const {children, ...otherProps} = props;
+  return (
+    <RSNavItem {...otherProps}>
+      {children}
+    </RSNavItem>
+  );
+}
+
+NavItem.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * HTML tag to use for the NavItem, default: li
+   */
+  tag: PropTypes.string,
+
+  /**
+   * Apply active style to item.
+   */
+  active: PropTypes.bool
+}
+
+export default NavItem;

--- a/src/components/nav/NavItem.js
+++ b/src/components/nav/NavItem.js
@@ -34,11 +34,6 @@ NavItem.propTypes = {
   className: PropTypes.string,
 
   /**
-   * HTML tag to use for the NavItem, default: li
-   */
-  tag: PropTypes.string,
-
-  /**
    * Apply active style to item.
    */
   active: PropTypes.bool

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react'
 import classNames from 'classnames';
-import DashLink from '../base/DashLink';
+import Link from '../../private/Link';
 
 const NavLink = ({ children, className, active, ...otherProps }) => {
   const classes = classNames(
@@ -10,9 +10,9 @@ const NavLink = ({ children, className, active, ...otherProps }) => {
     { active, disabled: otherProps.disabled }
   );
   return (
-    <DashLink className={classes} {...otherProps}>
+    <Link className={classes} {...otherProps}>
       {children}
-    </DashLink>
+    </Link>
   );
 }
 

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {NavLink as RSNavLink} from 'reactstrap';
+import React from 'react'
 import classNames from 'classnames';
 import DashLink from '../base/DashLink';
 

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -7,13 +7,18 @@ const NavLink = ({ children, className, active, ...otherProps }) => {
   const classes = classNames(
     className,
     'nav-link',
-    { active }
+    { active, disabled: otherProps.disabled }
   );
   return (
     <DashLink className={classes} {...otherProps}>
       {children}
     </DashLink>
   );
+}
+
+NavLink.defaultProps = {
+  active: false,
+  disabled: false
 }
 
 NavLink.propTypes = {

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,28 +1,19 @@
 import PropTypes from 'prop-types';
 import {NavLink as RSNavLink} from 'reactstrap';
+import classNames from 'classnames';
+import DashLink from '../base/DashLink';
 
-const NavLink = props => {
-  const {
-    children,
-    ...otherProps
-  } = props;
-  return (<RSNavLink {...otherProps} onClick={() => {
-      if (props.setProps) {
-        props.setProps({
-          n_clicks: props.n_clicks + 1,
-          n_clicks_timestamp: Date.now()
-        })
-      }
-      if (props.fireEvent)
-        props.fireEvent({event: 'click'});
-  }}>
-    {children}
-  </RSNavLink>);
-}
-
-NavLink.defaultProps = {
-  n_clicks: 0,
-  n_clicks_timestamp: -1
+const NavLink = ({ children, className, active, ...otherProps }) => {
+  const classes = classNames(
+    className,
+    'nav-link',
+    { active }
+  );
+  return (
+    <DashLink className={classes} {...otherProps}>
+      {children}
+    </DashLink>
+  );
 }
 
 NavLink.propTypes = {
@@ -64,7 +55,7 @@ NavLink.propTypes = {
   tag: PropTypes.string,
 
   /**
-   * Apply the disabled CSS class
+   * Disable the link
    */
   disabled: PropTypes.bool,
 

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -55,19 +55,9 @@ NavLink.propTypes = {
   active: PropTypes.bool,
 
   /**
-   * HTML tag to use for the link, default: a
-   */
-  tag: PropTypes.string,
-
-  /**
    * Disable the link
    */
   disabled: PropTypes.bool,
-
-  /**
-   * A callback for firing events to dash.
-   */
-  fireEvent: PropTypes.func,
 
   dashEvents: PropTypes.oneOf(['click'])
 }

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import {NavLink as RSNavLink} from 'reactstrap';
+
+const NavLink = props => {
+  const {
+    children,
+    ...otherProps
+  } = props;
+  return (<RSNavLink {...otherProps} onClick={() => {
+      if (props.setProps) {
+        props.setProps({
+          n_clicks: props.n_clicks + 1,
+          n_clicks_timestamp: Date.now()
+        })
+      }
+      if (props.fireEvent)
+        props.fireEvent({event: 'click'});
+  }}>
+    {children}
+  </RSNavLink>);
+}
+
+NavLink.defaultProps = {
+  n_clicks: 0,
+  n_clicks_timestamp: -1
+}
+
+NavLink.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * The URL of the linked resource.
+   */
+  href: PropTypes.string,
+
+  /**
+   * Apply 'active' style to this component
+   */
+  active: PropTypes.bool,
+
+  /**
+   * HTML tag to use for the link, default: a
+   */
+  tag: PropTypes.string,
+
+  /**
+   * Apply the disabled CSS class
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * A callback for firing events to dash.
+   */
+  fireEvent: PropTypes.func,
+
+  dashEvents: PropTypes.oneOf(['click'])
+}
+
+export default NavLink;

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import {
   Collapse,
   Container,
-  Nav,
-  NavbarToggler,
   Navbar as RSNavbar,
 } from 'reactstrap';
 
 import Link from '../../private/Link';
 
-import NavbarBrand from './NavbarBrand'
+import Nav from './Nav';
+import NavbarBrand from './NavbarBrand';
+import NavbarToggler from './NavbarToggler';
 
 class Navbar extends React.Component {
   constructor(props) {

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -134,6 +134,15 @@ Navbar.propTypes = {
   fixed: PropTypes.string,
 
   /**
+   * Stick the navbar to the top or the bottom of the viewport, options: top, bottom
+   *
+   * With `sticky`, the navbar remains in the viewport when you scroll. By
+   * contrast, with `fixed`, the navbar will remain at the top or bottom of
+   * the page.
+   */
+  sticky: PropTypes.string,
+
+  /**
    * Sets the color of the Navbar, options: primary, secondary, success, warning, danger, info, light.
    */
   color: PropTypes.string,

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -44,7 +44,7 @@ class Navbar extends React.Component {
         <Container fluid={fluid}>
           {brand && <NavbarBrand href={brand_href} style={brand_style} external_link={brand_external_link}>{brand}</NavbarBrand>}
           <NavbarToggler onClick={this.toggle} />
-          <Collapse isOpen={this.state.isOpen} navbar={true} >
+          <Collapse isOpen={this.state.isOpen} navbar>
             <Nav
               className={linksLeft ? "mr-auto" : "ml-auto"}
               navbar

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -31,8 +31,8 @@ class Navbar extends React.Component {
     const {
       children,
       brand,
-      brandHref,
-      brandStyle,
+      brand_href,
+      brand_style,
       brand_external_link,
       linksLeft,
       fluid,
@@ -42,7 +42,7 @@ class Navbar extends React.Component {
     return (
       <RSNavbar {...otherProps}>
         <Container fluid={fluid}>
-          {brand && <NavbarBrand href={brandHref} style={brandStyle} external_link={brand_external_link}>{brand}</NavbarBrand>}
+          {brand && <NavbarBrand href={brand_href} style={brand_style} external_link={brand_external_link}>{brand}</NavbarBrand>}
           <NavbarToggler onClick={this.toggle} />
           <Collapse isOpen={this.state.isOpen} navbar={true} >
             <Nav
@@ -96,12 +96,12 @@ Navbar.propTypes = {
   /**
    * Link to attach to brand
    */
-  brandHref: PropTypes.string,
+  brand_href: PropTypes.string,
 
   /**
    * Style options for Brand
    */
-  brandStyle: PropTypes.object,
+  brand_style: PropTypes.object,
 
   /**
    * If true, the browser will treat the brand link as external,

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Collapse,
+  Container,
+  Nav,
+  NavbarToggler,
+  NavbarBrand,
+  Navbar as RSNavbar,
+} from 'reactstrap';
+
+class Navbar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+    };
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle() {
+    this.setState({
+      isOpen: !this.state.isOpen
+    });
+  }
+
+  render() {
+    const {
+      children,
+      brand,
+      brandHref,
+      brandStyle,
+      linksLeft,
+      fluid,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <RSNavbar {...otherProps}>
+        <Container fluid={fluid}>
+          {brand && <NavbarBrand href={brandHref} style={brandStyle} >{brand}</NavbarBrand>}
+          <NavbarToggler onClick={this.toggle} />
+          <Collapse isOpen={this.state.isOpen} navbar={true} >
+            <Nav
+              className={linksLeft ? "mr-auto" : "ml-auto"}
+              navbar
+            >
+              {children}
+            </Nav>
+          </Collapse>
+        </Container>
+      </RSNavbar>
+    )
+  }
+}
+
+Navbar.defaultProps = {
+  fluid: false,
+  color: "light",
+  light: true,
+  expand: "md"
+}
+
+Navbar.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Branding text, to go top left of the navbar
+   */
+  brand: PropTypes.string,
+
+  /**
+   * Link to attach to brand
+   */
+  brandHref: PropTypes.string,
+
+  /**
+   * Style options for Brand
+   */
+  brandStyle: PropTypes.object,
+
+  /**
+   * Allow menu items to expand to fill width of page
+   */
+  fluid: PropTypes.bool,
+
+  /**
+   * Apply light styling to the navbar
+   */
+  light: PropTypes.bool,
+
+  /**
+   * Apply dark styling to the navbar
+   */
+  dark: PropTypes.bool,
+
+  /**
+   * Fix the navbar's position at the top or bottom of the page, options: top, bottom
+   */
+  fixed: PropTypes.string,
+
+  /**
+   * Sets the color of the Navbar, options: primary, secondary, success, warning, danger, info, light.
+   */
+  color: PropTypes.string,
+
+  /**
+   * HTML tag to use for the Navbar, default: nav
+   */
+  tag: PropTypes.string,
+
+  /**
+   * Specify screen size at which to expand the menu bar, e.g. sm, md, lg etc.
+   */
+  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+}
+
+export default Navbar;

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -5,9 +5,12 @@ import {
   Container,
   Nav,
   NavbarToggler,
-  NavbarBrand,
   Navbar as RSNavbar,
 } from 'reactstrap';
+
+import Link from '../../private/Link';
+
+import NavbarBrand from './NavbarBrand'
 
 class Navbar extends React.Component {
   constructor(props) {
@@ -30,6 +33,7 @@ class Navbar extends React.Component {
       brand,
       brandHref,
       brandStyle,
+      brand_external_link,
       linksLeft,
       fluid,
       ...otherProps
@@ -38,7 +42,7 @@ class Navbar extends React.Component {
     return (
       <RSNavbar {...otherProps}>
         <Container fluid={fluid}>
-          {brand && <NavbarBrand href={brandHref} style={brandStyle} >{brand}</NavbarBrand>}
+          {brand && <NavbarBrand href={brandHref} style={brandStyle} external_link={brand_external_link}>{brand}</NavbarBrand>}
           <NavbarToggler onClick={this.toggle} />
           <Collapse isOpen={this.state.isOpen} navbar={true} >
             <Nav
@@ -98,6 +102,16 @@ Navbar.propTypes = {
    * Style options for Brand
    */
   brandStyle: PropTypes.object,
+
+  /**
+   * If true, the browser will treat the brand link as external,
+   * forcing a page refresh at the new location. If false,
+   * this just changes the location without triggering a page
+   * refresh. Use this if you are observing dcc.Location, for
+   * instance. Defaults to true for absolute URLs and false
+   * otherwise.
+   */
+  brand_external_link: PropTypes.bool,
 
   /**
    * Allow menu items to expand to fill width of page

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -139,11 +139,6 @@ Navbar.propTypes = {
   color: PropTypes.string,
 
   /**
-   * HTML tag to use for the Navbar, default: nav
-   */
-  tag: PropTypes.string,
-
-  /**
    * Specify screen size at which to expand the menu bar, e.g. sm, md, lg etc.
    */
   expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])

--- a/src/components/nav/NavbarBrand.js
+++ b/src/components/nav/NavbarBrand.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import {NavbarBrand as RSNavbarBrand} from 'reactstrap';
+import Link from '../../private/Link';
+
+const NavbarBrand = props => {
+  const {
+    children,
+    ...otherProps
+  } = props;
+  return (<RSNavbarBrand {...otherProps} tag={Link}>
+    {children}
+  </RSNavbarBrand>);
+}
+
+NavbarBrand.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * If true, the browser will treat this as an external link,
+   * forcing a page refresh at the new location. If false,
+   * this just changes the location without triggering a page
+   * refresh. Use this if you are observing dcc.Location, for
+   * instance. Defaults to true for absolute URLs and false
+   * otherwise.
+   */
+  external_link: PropTypes.bool,
+
+  /**
+   * URL of the linked resource
+   */
+  href: PropTypes.string
+}
+
+export default NavbarBrand;

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import {NavbarToggler as RSNavbarToggler} from 'reactstrap';
+
+const NavbarToggler = props => {
+  const {
+    children,
+    ...otherProps
+  } = props;
+  return (<RSNavbarToggler {...otherProps}>
+    {children}
+  </RSNavbarToggler>);
+}
+
+NavbarToggler.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The children of this component
+   */
+  children: PropTypes.node,
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Toggle type, default: button.
+   */
+  type: PropTypes.string
+}
+
+export default NavbarToggler;

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -14,5 +14,13 @@ describe('NavLink', () => {
   it('contain a Link', () =>
     expect(link).toHaveLength(1)
   )
+
+  it('the link should have the correct href', () =>
+    expect(link.prop('href')).toEqual('http://example.com')
+  )
+
+  it('the link should have the correct inner text', () =>
+    expect(link.prop('children')).toEqual('Some text')
+  )
   
 })

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -22,5 +22,9 @@ describe('NavLink', () => {
   it('the link should have the correct inner text', () =>
     expect(link.prop('children')).toEqual('Some text')
   )
+
+  it('contain the nav-link class', () =>
+    expect(link.prop('className').split(' ')).toContain('nav-link')
+  )
   
 })

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import NavLink from '../NavLink';
+
+describe('NavLink', () => {
+  let link;
+  let dashLink;
+
+  beforeAll(() => {
+    link = shallow(<NavLink href="http://example.com">Some text</NavLink>)
+    dashLink = link.find('DashLink')
+  })
+
+  it('contain a DashLink', () =>
+    expect(dashLink).toHaveLength(1)
+  )
+  
+})

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -28,3 +28,35 @@ describe('NavLink', () => {
   )
   
 })
+
+describe('NavLink -- options', () => {
+  it('active', () => {
+    const navLink = shallow(
+      <NavLink href="http://example.com" active>Some text</NavLink>
+    )
+    const link = navLink.find('Link')
+    expect(link.prop('className').split(' ')).toContain('nav-link')
+    expect(link.prop('className').split(' ')).toContain('active')
+  })
+
+  it('disabled', () => {
+    const navLink = shallow(
+      <NavLink href="http://example.com" disabled>Some text</NavLink>
+    )
+    const link = navLink.find('Link')
+    const classes = link.prop('className').split(' ')
+    expect(classes).toContain('nav-link')
+    expect(classes).toContain('disabled')
+    expect(link.prop('disabled')).toBe(true)
+  })
+
+  it('additional classes', () => {
+    const navLink = shallow(
+      <NavLink href="http://example.com" className="some-class">Some text</NavLink>
+    )
+    const link = navLink.find('Link')
+    const classes = link.prop('className').split(' ')
+    expect(classes).toContain('nav-link')
+    expect(classes).toContain('some-class')
+  })
+})

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -3,16 +3,16 @@ import {shallow} from 'enzyme';
 import NavLink from '../NavLink';
 
 describe('NavLink', () => {
+  let navLink;
   let link;
-  let dashLink;
 
   beforeAll(() => {
-    link = shallow(<NavLink href="http://example.com">Some text</NavLink>)
-    dashLink = link.find('DashLink')
+    navLink = shallow(<NavLink href="http://example.com">Some text</NavLink>)
+    link = navLink.find('Link')
   })
 
-  it('contain a DashLink', () =>
-    expect(dashLink).toHaveLength(1)
+  it('contain a Link', () =>
+    expect(link).toHaveLength(1)
   )
   
 })

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -58,3 +58,21 @@ describe('Navbar with brand', () => {
     expect(navbarBrand.prop('external_link')).toBe(true)
   })
 })
+
+describe('Expandable navbar', () => {
+  let navbar;
+  let rsNavbar;
+
+  beforeAll(() => {
+    navbar = shallow(
+      <Navbar expand="xl">
+        <NavItem>item</NavItem>
+      </Navbar>
+    )
+    rsNavbar = navbar.find(RSNavbar)
+  })
+
+  it('pass on expand prop to underlying Reactstrap navbar', () =>
+    expect(rsNavbar.prop('expand')).toEqual('xl')
+  )
+})

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -1,0 +1,35 @@
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import Navbar from '../Navbar';
+import NavbarBrand from '../NavbarBrand';
+import NavItem from '../NavItem';
+
+describe('Navbar with brand', () => {
+  let navbar;
+  let navbarBrand;
+
+  beforeAll(() => {
+    navbar = shallow(
+      <Navbar
+        brand="some-brand"
+        brand_href="https://example.com"
+        brand_style={{'background-color': 'red'}}
+        brand_external_link={true}
+      >
+        <NavItem>item</NavItem>
+      </Navbar>
+    );
+    navbarBrand = navbar.find(NavbarBrand);
+  })
+
+  it('contain a NavbarBrand', () =>
+    expect(navbarBrand).toHaveLength(1)
+  )
+
+  it('pass props onto the NavbarBrand', () => {
+    expect(navbarBrand.prop('href')).toEqual('https://example.com')
+    expect(navbarBrand.prop('style')).toEqual({'background-color': 'red'})
+    expect(navbarBrand.prop('external_link')).toBe(true)
+  })
+})

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -59,20 +59,55 @@ describe('Navbar with brand', () => {
   })
 })
 
-describe('Expandable navbar', () => {
-  let navbar;
-  let rsNavbar;
+describe('Pass on attributes to the underlying reactstrap navbar', () => {
 
-  beforeAll(() => {
-    navbar = shallow(
+  it('expand', () => {
+    const navbar = shallow(
       <Navbar expand="xl">
         <NavItem>item</NavItem>
       </Navbar>
     )
-    rsNavbar = navbar.find(RSNavbar)
+    const rsNavbar = navbar.find(RSNavbar)
+    expect(rsNavbar.prop('expand')).toEqual('xl')
   })
 
-  it('pass on expand prop to underlying Reactstrap navbar', () =>
-    expect(rsNavbar.prop('expand')).toEqual('xl')
-  )
+  it('dark', () => {
+    const navbar = shallow(
+      <Navbar dark={true}>
+        <NavItem>item</NavItem>
+      </Navbar>
+    )
+    const rsNavbar = navbar.find(RSNavbar)
+    expect(rsNavbar.prop('dark')).toBe(true)
+  })
+
+  it('light', () => {
+    const navbar = shallow(
+      <Navbar light={true}>
+        <NavItem>item</NavItem>
+      </Navbar>
+    )
+    const rsNavbar = navbar.find(RSNavbar)
+    expect(rsNavbar.prop('light')).toBe(true)
+  })
+
+  it('fixed', () => {
+    const navbar = shallow(
+      <Navbar fixed="top">
+        <NavItem>item</NavItem>
+      </Navbar>
+    )
+    const rsNavbar = navbar.find(RSNavbar)
+    expect(rsNavbar.prop('fixed')).toBe('top')
+  })
+
+  it('color', () => {
+    const navbar = shallow(
+      <Navbar color="secondary">
+        <NavItem>item</NavItem>
+      </Navbar>
+    )
+    const rsNavbar = navbar.find(RSNavbar)
+    expect(rsNavbar.prop('color')).toBe('secondary')
+  })
 })

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -91,8 +91,14 @@ describe('Pass on attributes to the underlying reactstrap navbar', () => {
     expect(rsNavbar.prop('fixed')).toBe('top')
   })
 
+  it('sticky', () => {
+    const {navbar, rsNavbar} = navbarWithProps({sticky: 'top'})
+    expect(rsNavbar.prop('sticky')).toBe('top')
+  })
+
   it('color', () => {
     const {navbar, rsNavbar} = navbarWithProps({color: 'secondary'})
     expect(rsNavbar.prop('color')).toBe('secondary')
   })
+
 })

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -61,53 +61,38 @@ describe('Navbar with brand', () => {
 
 describe('Pass on attributes to the underlying reactstrap navbar', () => {
 
-  it('expand', () => {
+  function navbarWithProps(props) {
     const navbar = shallow(
-      <Navbar expand="xl">
+      <Navbar {...props}>
         <NavItem>item</NavItem>
       </Navbar>
     )
     const rsNavbar = navbar.find(RSNavbar)
+    return {navbar, rsNavbar}
+  }
+
+  it('expand', () => {
+    const {navbar, rsNavbar} = navbarWithProps({expand: 'xl'})
     expect(rsNavbar.prop('expand')).toEqual('xl')
   })
 
   it('dark', () => {
-    const navbar = shallow(
-      <Navbar dark={true}>
-        <NavItem>item</NavItem>
-      </Navbar>
-    )
-    const rsNavbar = navbar.find(RSNavbar)
+    const {navbar, rsNavbar} = navbarWithProps({dark: true})
     expect(rsNavbar.prop('dark')).toBe(true)
   })
 
   it('light', () => {
-    const navbar = shallow(
-      <Navbar light={true}>
-        <NavItem>item</NavItem>
-      </Navbar>
-    )
-    const rsNavbar = navbar.find(RSNavbar)
+    const {navbar, rsNavbar} = navbarWithProps({light: true})
     expect(rsNavbar.prop('light')).toBe(true)
   })
 
   it('fixed', () => {
-    const navbar = shallow(
-      <Navbar fixed="top">
-        <NavItem>item</NavItem>
-      </Navbar>
-    )
-    const rsNavbar = navbar.find(RSNavbar)
+    const {navbar, rsNavbar} = navbarWithProps({fixed: 'top'})
     expect(rsNavbar.prop('fixed')).toBe('top')
   })
 
   it('color', () => {
-    const navbar = shallow(
-      <Navbar color="secondary">
-        <NavItem>item</NavItem>
-      </Navbar>
-    )
-    const rsNavbar = navbar.find(RSNavbar)
+    const {navbar, rsNavbar} = navbarWithProps({color: 'secondary'})
     expect(rsNavbar.prop('color')).toBe('secondary')
   })
 })

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -5,6 +5,24 @@ import Navbar from '../Navbar';
 import NavbarBrand from '../NavbarBrand';
 import NavItem from '../NavItem';
 
+describe('Empty Navbar', () => {
+  let navbar;
+  let navbarBrand;
+
+  beforeAll(() => {
+    navbar = shallow(
+      <Navbar>
+        <NavItem>item</NavItem>
+      </Navbar>
+    );
+    navbarBrand = navbar.find(NavbarBrand);
+  })
+
+  it('should not have a brand', () =>
+    expect(navbarBrand).toHaveLength(0)
+  )
+})
+
 describe('Navbar with brand', () => {
   let navbar;
   let navbarBrand;

--- a/src/components/nav/__tests__/Navbar.test.js
+++ b/src/components/nav/__tests__/Navbar.test.js
@@ -1,12 +1,14 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import {Navbar as RSNavbar} from 'reactstrap';
 import Navbar from '../Navbar';
 import NavbarBrand from '../NavbarBrand';
 import NavItem from '../NavItem';
 
 describe('Empty Navbar', () => {
   let navbar;
+  let rsNavbar;
   let navbarBrand;
 
   beforeAll(() => {
@@ -15,8 +17,13 @@ describe('Empty Navbar', () => {
         <NavItem>item</NavItem>
       </Navbar>
     );
+    rsNavbar = navbar.find(RSNavbar)
     navbarBrand = navbar.find(NavbarBrand);
   })
+
+  it('should contain a reactstrap Navbar', () =>
+    expect(rsNavbar).toHaveLength(1)
+  )
 
   it('should not have a brand', () =>
     expect(navbarBrand).toHaveLength(0)

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,12 @@ export { default as ListGroup } from './components/listgroup/ListGroup';
 export { default as ListGroupItem } from './components/listgroup/ListGroupItem';
 export { default as ListGroupItemHeading } from './components/listgroup/ListGroupItemHeading';
 export { default as ListGroupItemText } from './components/listgroup/ListGroupItemText';
-export { default as Navbar } from './components/nav/Navbar'
-export { default as NavItem } from './components/nav/NavItem'
-export { default as NavLink } from './components/nav/NavLink'
+export { default as Nav } from './components/nav/Nav';
+export { default as Navbar } from './components/nav/Navbar';
+export { default as NavbarBrand } from './components/nav/Navbar';
+export { default as NavbarToggler } from './components/nav/NavbarToggler';
+export { default as NavItem } from './components/nav/NavItem';
+export { default as NavLink } from './components/nav/NavLink';
 export { default as Popover } from './components/Popover';
 export { default as PopoverBody } from './components/PopoverBody';
 export { default as PopoverHeader } from './components/PopoverHeader';

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ export { default as ListGroupItem } from './components/listgroup/ListGroupItem';
 export { default as ListGroupItemHeading } from './components/listgroup/ListGroupItemHeading';
 export { default as ListGroupItemText } from './components/listgroup/ListGroupItemText';
 export { default as Navbar } from './components/nav/Navbar'
+export { default as NavItem } from './components/nav/NavItem'
+export { default as NavLink } from './components/nav/NavLink'
 export { default as Popover } from './components/Popover';
 export { default as PopoverBody } from './components/PopoverBody';
 export { default as PopoverHeader } from './components/PopoverHeader';

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export { default as ListGroup } from './components/listgroup/ListGroup';
 export { default as ListGroupItem } from './components/listgroup/ListGroupItem';
 export { default as ListGroupItemHeading } from './components/listgroup/ListGroupItemHeading';
 export { default as ListGroupItemText } from './components/listgroup/ListGroupItemText';
+export { default as Navbar } from './components/nav/Navbar'
 export { default as Popover } from './components/Popover';
 export { default as PopoverBody } from './components/PopoverBody';
 export { default as PopoverHeader } from './components/PopoverHeader';

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -39,6 +39,10 @@ class Link extends Component {
   }
 
   updateLocation(e) {
+    if (this.props.disabled) {
+      e.preventDefault();
+      return
+    }
     if (!this.isExternalLink()) {
       // prevent anchor from updating location
       e.preventDefault();
@@ -102,6 +106,11 @@ Link.propTypes = {
   href: PropTypes.string,
 
   /**
+   * If true, clicking on the link does nothing.
+   */
+  disabled: PropTypes.bool,
+
+  /**
    * If true, the browser will treat this as an external link,
    * forcing a page refresh at the new location. If false,
    * this just changes the location without triggering a page
@@ -128,6 +137,7 @@ Link.propTypes = {
 Link.defaultProps = {
   n_clicks: 0,
   n_clicks_timestamp: -1,
+  disabled: false,
   external_link: null
 };
 

--- a/src/private/__tests__/Link.test.js
+++ b/src/private/__tests__/Link.test.js
@@ -147,7 +147,7 @@ describe('Link -- behaviour', () => {
 
     beforeAll(() => {
       jsdom.reconfigure({ url: 'http://starting-url.com' })
-      link = mount(<DashLink href="http://example.com" disabled={true}>inner text</DashLink>);
+      link = mount(<Link href="http://example.com" disabled={true}>inner text</Link>);
       const anchor = link.find('a')
       clickEvent = {preventDefault: jest.fn()} // spy on preventDefault
       anchor.simulate('click', clickEvent)

--- a/src/private/__tests__/Link.test.js
+++ b/src/private/__tests__/Link.test.js
@@ -121,7 +121,7 @@ describe('Link -- behaviour', () => {
     })
 
     it('redirect an internal link', () =>
-      expect(window.location.toString()).toEqual(`http://starting-url.com/example`)
+      expect(window.location.toString()).toEqual('http://starting-url.com/example')
     )
 
     it('scroll the window', () =>
@@ -135,6 +135,31 @@ describe('Link -- behaviour', () => {
     it('prevent the default event handler', () =>
       expect(clickEvent.preventDefault).toHaveBeenCalled()
     )
+
+    afterAll(() => {
+      link.unmount()
+    })
+  })
+
+  describe('do nothing if disabled is true', () => {
+    let link;
+    let clickEvent;
+
+    beforeAll(() => {
+      jsdom.reconfigure({ url: 'http://starting-url.com' })
+      link = mount(<DashLink href="http://example.com" disabled={true}>inner text</DashLink>);
+      const anchor = link.find('a')
+      clickEvent = {preventDefault: jest.fn()} // spy on preventDefault
+      anchor.simulate('click', clickEvent)
+    })
+
+    it('prevent default event behaviour', () => {
+      expect(clickEvent.preventDefault).toHaveBeenCalled()
+    })
+
+    it('not change the location', () => {
+      expect(window.location.toString()).toEqual('http://starting-url.com/')
+    })
 
     afterAll(() => {
       link.unmount()


### PR DESCRIPTION
This PR adds navbar and nav components.

<img width="1440" alt="screen shot 2018-10-02 at 07 07 25" src="https://user-images.githubusercontent.com/1392879/46331894-de3bba00-c611-11e8-880c-30c21de1298e.png">

There's some very basic unit tests for some of the more complicated components (`NavLink` and `Navbar`).

I have not migrated higher-order layout components like `NavbarPage`, since I thought it'd be useful to have a discussion about those.