### PR TITLE
Dropdownitem links

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -4,12 +4,14 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output, State
 
+DBC_GITHUB = "https://github.com/ASIDataScience/dash-bootstrap-components"
+
 app = dash.Dash()
 
 
 navbar = dbc.Navbar(
     brand="Dash Bootstrap components",
-    brand_href="https://github.com/ASIDataScience/dash-bootstrap-components",
+    brand_href=DBC_GITHUB,
     sticky="top",
     children=[
         dbc.NavItem(dbc.NavLink("ASI", href="https://www.asidatascience.com")),
@@ -241,7 +243,7 @@ dropdown = html.Div(
         dbc.Dropdown(
             [
                 dbc.DropdownItem("Heading", header=True),
-                dbc.DropdownItem(dcc.Link("Item 1")),
+                dbc.DropdownItem("Item 1", href=DBC_GITHUB),
                 dbc.DropdownItem(divider=True),
                 dbc.DropdownItem("Another heading", header=True),
                 dbc.DropdownItem("Item 2"),

--- a/examples/app.py
+++ b/examples/app.py
@@ -18,13 +18,17 @@ navbar = dbc.Navbar(
             inNavbar=True,
             label="Menu",
             children=[
-                dbc.DropdownItem("Entry 1"),
-                dbc.DropdownItem("Entry 2"),
+                dbc.DropdownItem("Entry 1", href="https://google.com"),
+                dbc.DropdownItem("Entry 2", href="/test"),
                 dbc.DropdownItem(divider=True),
-                dbc.DropdownItem("Entry 3"),
-            ]
-        )
-    ]
+                dbc.DropdownItem("A heading", header=True),
+                dbc.DropdownItem(
+                    "Entry 3", href="/external-test", external_link=True
+                ),
+                dbc.DropdownItem("Entry 4 - does nothing"),
+            ],
+        ),
+    ],
 )
 
 header = html.Div(
@@ -262,14 +266,18 @@ fade = html.Div(
     ]
 )
 
-jumbotron = html.Div([
-    html.H2("Jumbotron"),
-    dbc.Jumbotron([
-        html.H2("This is a jumbotron"),
-        html.P("It makes things big..."),
-        dbc.Button("Click here", color="danger"),
-    ])
-])
+jumbotron = html.Div(
+    [
+        html.H2("Jumbotron"),
+        dbc.Jumbotron(
+            [
+                html.H2("This is a jumbotron"),
+                html.P("It makes things big..."),
+                dbc.Button("Click here", color="danger"),
+            ]
+        ),
+    ]
+)
 
 list_group = html.Div(
     [
@@ -410,44 +418,48 @@ tooltip = html.Div(
     ]
 )
 
-app.layout = html.Div([
-    navbar,
-    dbc.Container([
-        dcc.Interval(id="interval", interval=500, n_intervals=0),
-        header,
-        html.Br(),
-        alerts,
-        html.Br(),
-        badges,
-        html.Br(),
-        buttons,
-        html.Br(),
-        cards,
-        html.Br(),
-        collapse,
-        html.Br(),
-        columns,
-        html.Br(),
-        dropdown,
-        html.Br(),
-        fade,
-        html.Br(),
-        jumbotron,
-        html.Br(),
-        list_group,
-        html.Br(),
-        popover,
-        html.Br(),
-        progress,
-        html.Br(),
-        table,
-        html.Br(),
-        tabs,
-        html.Br(),
-        tooltip,
-        html.Div(style={"height": "200px"}),
-    ])
-])
+app.layout = html.Div(
+    [
+        navbar,
+        dbc.Container(
+            [
+                dcc.Interval(id="interval", interval=500, n_intervals=0),
+                header,
+                html.Br(),
+                alerts,
+                html.Br(),
+                badges,
+                html.Br(),
+                buttons,
+                html.Br(),
+                cards,
+                html.Br(),
+                collapse,
+                html.Br(),
+                columns,
+                html.Br(),
+                dropdown,
+                html.Br(),
+                fade,
+                html.Br(),
+                jumbotron,
+                html.Br(),
+                list_group,
+                html.Br(),
+                popover,
+                html.Br(),
+                progress,
+                html.Br(),
+                table,
+                html.Br(),
+                tabs,
+                html.Br(),
+                tooltip,
+                html.Div(style={"height": "200px"}),
+            ]
+        ),
+    ]
+)
 
 
 @app.callback(

--- a/examples/navitem_test.py
+++ b/examples/navitem_test.py
@@ -1,0 +1,52 @@
+import dash
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+app = dash.Dash()
+
+navbar = dbc.Navbar(
+    brand="Dash Bootstrap components",
+    brand_href="https://github.com/ASIDataScience/dash-bootstrap-components",
+    sticky="top",
+    children=[
+        dbc.NavItem(dbc.NavLink("ASI", href="https://www.asidatascience.com")),
+        dbc.Dropdown(
+            nav=True,
+            inNavbar=True,
+            label="Menu",
+            children=[
+                dbc.DropdownItem("Entry 1", href="https://google.com"),
+                dbc.DropdownItem("Entry 2", href="/test", id="dd-internal"),
+                dbc.DropdownItem(divider=True),
+                dbc.DropdownItem("A heading", header=True),
+                dbc.DropdownItem(
+                    "Entry 3", href="/external-test", external_link=True
+                ),
+                dbc.DropdownItem("Entry 4 - does nothing", id="dd-button"),
+            ],
+        ),
+    ],
+)
+
+app.layout = html.Div(
+    [navbar, html.Div(id="counter"), html.Div(id="counter2")]
+)
+
+
+@app.callback(Output("counter", "children"), [Input("dd-button", "n_clicks")])
+def count(n):
+    print(n)
+    return str(n)
+
+
+@app.callback(
+    Output("counter2", "children"), [Input("dd-internal", "n_clicks")]
+)
+def count2(n):
+    print(n)
+    return str(n)
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888)

--- a/examples/navitem_test.py
+++ b/examples/navitem_test.py
@@ -36,7 +36,6 @@ app.layout = html.Div(
 
 @app.callback(Output("counter", "children"), [Input("dd-button", "n_clicks")])
 def count(n):
-    print(n)
     return str(n)
 
 
@@ -44,7 +43,6 @@ def count(n):
     Output("counter2", "children"), [Input("dd-internal", "n_clicks")]
 )
 def count2(n):
-    print(n)
     return str(n)
 
 

--- a/src/components/DropdownItem.js
+++ b/src/components/DropdownItem.js
@@ -1,14 +1,33 @@
 import PropTypes from 'prop-types';
 import {DropdownItem as RSDropdownItem} from 'reactstrap';
+import Link from '../private/Link';
+import Button from './Button';
 
 const DropdownItem = props => {
   const {
     children,
+    href,
     ...otherProps
   } = props;
-  return (<RSDropdownItem {...otherProps}>
-    {children}
-  </RSDropdownItem>);
+  return (
+    <RSDropdownItem
+    onClick={() => {
+      if (props.setProps) {
+        props.setProps({
+          n_clicks: props.n_clicks + 1,
+          n_clicks_timestamp: Date.now()
+        })
+      }
+      if (props.fireEvent)
+        props.fireEvent({event: 'click'});
+      }
+    }
+    tag={href ? Link : 'button'}
+    href={href}
+    {...otherProps}>
+      {children}
+    </RSDropdownItem>
+  );
 }
 
 DropdownItem.propTypes = {
@@ -57,7 +76,42 @@ DropdownItem.propTypes = {
   /**
    * Link for the menu item
    */
-  href: PropTypes.string
+  href: PropTypes.string,
+
+  /**
+   * If true, the browser will treat this as an external link,
+   * forcing a page refresh at the new location. If false,
+   * this just changes the location without triggering a page
+   * refresh. Use this if you are observing dcc.Location, for
+   * instance. Defaults to true for absolute URLs and false
+   * otherwise.
+   */
+  external_link: PropTypes.bool,
+
+  /**
+   * An integer that represents the number of times
+   * that this element has been clicked on.
+   */
+  n_clicks: PropTypes.number,
+
+  /**
+   * An integer that represents the time (in ms since 1970)
+   * at which n_clicks changed. This can be used to tell
+   * which button was changed most recently.
+   */
+  n_clicks_timestamp: PropTypes.number,
+
+  /**
+   * A callback for firing events to dash.
+   */
+  fireEvent: PropTypes.func,
+
+  dashEvents: PropTypes.oneOf(['click'])
+};
+
+DropdownItem.defaultProps = {
+  n_clicks: 0,
+  n_clicks_timestamp: -1
 };
 
 export default DropdownItem;

--- a/src/components/DropdownItem.js
+++ b/src/components/DropdownItem.js
@@ -1,33 +1,43 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {DropdownItem as RSDropdownItem} from 'reactstrap';
 import Link from '../private/Link';
 import Button from './Button';
 
-const DropdownItem = props => {
-  const {
-    children,
-    href,
-    ...otherProps
-  } = props;
-  return (
-    <RSDropdownItem
-    onClick={() => {
-      if (props.setProps) {
-        props.setProps({
-          n_clicks: props.n_clicks + 1,
+class DropdownItem extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.incrementClicks = this.incrementClicks.bind(this);
+  }
+
+  incrementClicks() {
+    if (!this.props.disabled) {
+      if (this.props.setProps) {
+        this.props.setProps({
+          n_clicks: this.props.n_clicks + 1,
           n_clicks_timestamp: Date.now()
-        })
-      }
-      if (props.fireEvent)
-        props.fireEvent({event: 'click'});
+        });
       }
     }
-    tag={href ? Link : 'button'}
-    href={href}
-    {...otherProps}>
-      {children}
-    </RSDropdownItem>
-  );
+  }
+
+  render() {
+    let {
+      children,
+      href,
+      ...otherProps
+    } = this.props;
+    otherProps[href ? "preOnClick" : "onClick"] = this.incrementClicks;
+    return (
+      <RSDropdownItem
+      tag={href ? Link : 'button'}
+      href={href}
+      {...otherProps}>
+        {children}
+      </RSDropdownItem>
+    );
+  }
 }
 
 DropdownItem.propTypes = {
@@ -99,14 +109,7 @@ DropdownItem.propTypes = {
    * at which n_clicks changed. This can be used to tell
    * which button was changed most recently.
    */
-  n_clicks_timestamp: PropTypes.number,
-
-  /**
-   * A callback for firing events to dash.
-   */
-  fireEvent: PropTypes.func,
-
-  dashEvents: PropTypes.oneOf(['click'])
+  n_clicks_timestamp: PropTypes.number
 };
 
 DropdownItem.defaultProps = {

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -129,7 +129,12 @@ Link.propTypes = {
    * at which n_clicks changed. This can be used to tell
    * which button was changed most recently.
    */
-  n_clicks_timestamp: PropTypes.number
+  n_clicks_timestamp: PropTypes.number,
+
+  /**
+   * Function to be executed on click before the redirect logic of Link.
+   */
+  preOnClick: PropTypes.func
 };
 
 Link.defaultProps = {

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -43,6 +43,9 @@ class Link extends Component {
       e.preventDefault();
       return
     }
+    if (this.props.preOnClick) {
+      this.props.preOnClick();
+    }
     if (!this.isExternalLink()) {
       // prevent anchor from updating location
       e.preventDefault();
@@ -52,18 +55,13 @@ class Link extends Component {
       // scroll back to top
       window.scrollTo(0, 0);
     }
-    if (this.props.setProps) {
-      this.props.setProps({
-        n_clicks: props.n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      })
-    }
   }
 
   render() {
     const {
       children,
       external_link,
+      preOnClick,
       ...otherProps
     } = this.props;
     /**


### PR DESCRIPTION
This PR adds better support for links in the `DropdownItem` component.

Currently it looks at the `href` attribute. If this is not present it creates a html button with the correct styling and can be used in callbacks by watching `n_clicks`. If `href` is present, then a `Link` component from `private` is used.

There is one problem with the current implementation which is that when `href` is specified and `Link` gets used, the `onClick` attribute of `DropdownItem` is overwritten. This works well for allowing `DropdownItem` to either redirect to an external page or update the url depending on the form of `href` or the value of `external_link`. However, it does mean that the `n_clicks` and `n_clicks_timestamp` attributes are not properly updated, as `Link` updates these as internal props and the information doesn't flow back up.

There are two possibilities here as far as I can tell.

- Modify `Link` to allow the function that gets called on click to be modified by whichever component creates the `Link`. I guess this would result in complicating `Link`, but since it's an internal component maybe it's ok.
- Decide that there isn't really a reason to want to update the url and also use `n_clicks` to trigger a callback and simply have `n_clicks` not update when `href` has been specified. This does of course feel like a bit of a fudge.

Very happy to take some input on this.