### PR TITLE
Automate release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dash_bootstrap_components/metadata.json
 *__pycache__
 *.pyc
 dist
+changelog.tmp

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -1,0 +1,16 @@
+
+# How to release dash-bootstrap-components
+
+This is a set of instructions for releasing to Pypi. The release process is somewhat automated with an `invoke <http://docs.pyinvoke.org/en/latest/getting_started.html>`_ task file. You will need `invoke` and `semver` installed.
+
+ - Run ``invoke prerelease <version>``, where ``version`` is the version number of the release candidate. If you are aiming to release version ``0.0.7``, this will be ``0.0.7-rc1``. This will automatically bump the version numbers and upload the release to Pypi.
+
+ - Verify that you can install the new version and that it works correctly with ``pip install dash-bootstrap-components==<new version>``. It's best to verify the installation on a clean virtual machine (rather than just in a new environment) since installation is more complex than for pure Python packages.
+
+ - If the manual installation tests failed, fix the issue and repeat the previous steps with ``rc2`` etc. If installing worked, proceed to the next steps.
+
+ - Run ``invoke release <version>``, where ``version`` is the version number of the release (e.g. ``0.7.0``). You will be prompted to enter a changelog. This will create a release, push it to Pypi and add a tag on current master.
+
+ - Verify that the new version is available by running ``pip install dash-bootstrap-components`` in a new virtual environment.
+
+ - Run ``invoke postrelease <version>``, where ``version`` is the version number of the new release. This will change the version numbers back to a `-dev` version.

--- a/tasks.py
+++ b/tasks.py
@@ -62,6 +62,36 @@ def release(ctx, version):
 
     build_publish(version)
 
+    info("Committing version changes")
+    run('git add dash_bootstrap_components/_version.py')
+    run('git add package.json')
+    run(f'git commit -m "Bump version to {version}"')
+    info(f"Tagging version {version}")
+    run('git tag -a "{version}" -F changelog.tmp')
+    run('git push origin master --tags')
+
+
+@task(help={
+    'version': 'Version number to finalize. Must be '
+    'the same version number that was used in the release.'
+})
+def postrelease(ctx, version):
+    '''
+    Finalise the release
+    Running this task will:
+     - commit the version changes to source control
+     - tag the commit
+     - push changes to master
+    '''
+    new_version = semver.bump_patch(version) + '-dev'
+    info(f"Bumping version numbers to {new_version} and committing")
+    set_pyversion(new_version)
+    set_jsversion(new_version)
+    run('git add dash_bootstrap_components/_version.py')
+    run('git add package.json')
+    run('git commit -m "Back to dev"')
+    run('git push origin master')
+
 
 def build_publish(version):
     info("Cleaning")

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,105 @@
+
+import os
+from pathlib import Path
+
+from termcolor import cprint
+from invoke import task, run as invoke_run
+import semver
+
+VERSION_TEMPLATE = """
+__version__ = "{version_string}"
+"""
+
+HERE = Path(__file__).parent
+
+DASH_BOOTSTRAP_DIR = HERE / "dash_bootstrap_components"
+JS_DIR = HERE / "src"
+
+
+@task(help={'version': 'Version number to release'})
+def prerelease(ctx, version):
+    '''
+    Release a pre-release version
+    Running this task will:
+     - Bump the version number
+     - Push a release to pypi and npm
+    '''
+    info(f"Releasing version {version} as prerelease")
+    info("Cleaning")
+    clean()
+    info("Updating versions")
+    set_pyversion(version)
+    set_jsversion(version)
+    info("Building JavaScript components")
+    build_js()
+    info("Building and uploading Python source distribution")
+    release_python_sdist()
+
+
+def clean():
+    paths_to_clean = [
+        "src/node_modules",
+        "dash_bootstrap_components/bundle.js",
+        "dash_bootstrap_components/metadata.json",
+        "dist/",
+        "lib/"
+    ]
+    for path in paths_to_clean:
+        run(f"rm -rf {path}")
+
+
+def build_js():
+    os.chdir(JS_DIR)
+    try:
+        run("npm install")
+    finally:
+        os.chdir(HERE)
+
+
+def release_python_sdist():
+    run("rm -f dist/*")
+    run("python setup.py sdist")
+    invoke_run("twine upload dist/*")
+
+
+def set_pyversion(version):
+    version = normalize_version(version)
+    version_path = DASH_BOOTSTRAP_DIR / "_version.py"
+    with version_path.open("w") as f:
+        f.write(VERSION_TEMPLATE.format(version_string=version))
+
+
+def set_jsversion(version):
+    version = normalize_version(version)
+    package_json_path = HERE / "package.json"
+    with package_json_path.open() as f:
+        package_json = f.readlines()
+    for iline, line in enumerate(package_json):
+        if '"version"' in line:
+            package_json[iline] = '  "version": "{}",\n'.format(version)
+    with open(package_json_path, 'w') as f:
+        f.writelines(package_json)
+
+
+def normalize_version(version):
+    version_info = semver.parse_version_info(version)
+    version_string = str(version_info)
+    return version_string
+
+
+def run(command, **kwargs):
+    result = invoke_run(command, hide=True, warn=True, **kwargs)
+    if result.exited != 0:
+        error("Error running {}".format(command))
+        print(result.stdout)
+        print()
+        print(result.stderr)
+        exit(result.exited)
+
+
+def error(text):
+    cprint(text, "red")
+
+
+def info(text):
+    print(text)

--- a/tasks.py
+++ b/tasks.py
@@ -68,7 +68,7 @@ def release(ctx, version):
     run("git add package.json")
     run(f'git commit -m "Bump version to {version}"')
     info(f"Tagging version {version} and pushing to GitHub")
-    run('git tag -a "{version}" -F changelog.tmp')
+    run(f'git tag -a "{version}" -F changelog.tmp')
     run("git push origin master --tags")
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -64,8 +64,10 @@ def release(ctx, version):
     build_publish(version)
 
     info("Committing version changes")
-    run("git add dash_bootstrap_components/_version.py")
-    run("git add package.json")
+    run(
+        "git add package.json package-lock.json "
+        "dash_bootstrap_components/_version.py"
+    )
     run(f'git commit -m "Bump version to {version}"')
     info(f"Tagging version {version} and pushing to GitHub")
     run(f'git tag -a "{version}" -F changelog.tmp')
@@ -89,8 +91,10 @@ def postrelease(ctx, version):
     info(f"Bumping version numbers to {new_version} and committing")
     set_pyversion(new_version)
     set_jsversion(new_version)
-    run("git add dash_bootstrap_components/_version.py")
-    run("git add package.json")
+    run(
+        "git add package.json package-lock.json "
+        "dash_bootstrap_components/_version.py"
+    )
     run('git commit -m "Back to dev"')
     run("git push origin master")
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,7 @@
 
 import os
+import tempfile
+from subprocess import call
 from pathlib import Path
 
 from termcolor import cprint
@@ -9,6 +11,12 @@ import semver
 VERSION_TEMPLATE = """
 __version__ = "{version_string}"
 """
+
+RELEASE_NOTES_TEMPLATE = '''# Write the release notes here
+# Delete the version title to cancel
+Version {version_string}
+{underline}
+'''
 
 HERE = Path(__file__).parent
 
@@ -25,6 +33,37 @@ def prerelease(ctx, version):
      - Push a release to pypi and npm
     '''
     info(f"Releasing version {version} as prerelease")
+    build_publish(version)
+
+
+@task(help={'version': 'Version number to release'})
+def release(ctx, version):
+    '''
+    Release a new version
+    Running this task will:
+     - Prompt the user for a changelog and write it to
+       the release notes
+     - Commit the release notes
+     - Bump the version number
+     - Push a release to pypi and npm
+    '''
+    info(f"Releasing version {version} as full release")
+    release_notes_lines = get_release_notes(version)
+
+    if release_notes_lines is None:
+        error('No release notes: exiting')
+        exit()
+
+    info("Writing release notes to changelog.tmp")
+    with open("changelog.tmp", "w") as f:
+        f.writelines(release_notes_lines)
+
+    # TODO when we have release notes, these should be amended here
+
+    build_publish(version)
+
+
+def build_publish(version):
     info("Cleaning")
     clean()
     info("Updating versions")
@@ -79,6 +118,39 @@ def set_jsversion(version):
             package_json[iline] = '  "version": "{}",\n'.format(version)
     with open(package_json_path, 'w') as f:
         f.writelines(package_json)
+
+
+def get_release_notes(version):
+    version = normalize_version(version)
+    underline = '=' * len('Version {}'.format(version))
+    initial_message = RELEASE_NOTES_TEMPLATE.format(
+        version_string=version, underline=underline)
+    lines = open_editor(initial_message)
+    non_commented_lines = [line for line in lines if not line.startswith('#')]
+    changelog = ''.join(non_commented_lines)
+    if version in changelog:
+        if not non_commented_lines[-1].isspace():
+            non_commented_lines.append('\n')
+        return non_commented_lines
+    else:
+        return None
+
+
+def open_editor(initial_message):
+    editor = os.environ.get('EDITOR', 'vim')
+    tmp = tempfile.NamedTemporaryFile(suffix='.tmp')
+    fname = tmp.name
+
+    with open(fname, 'w') as f:
+        f.write(initial_message)
+        f.flush()
+
+    call([editor, fname], close_fds=True)
+
+    with open(fname, 'r') as f:
+        lines = f.readlines()
+
+    return lines
 
 
 def normalize_version(version):

--- a/tasks.py
+++ b/tasks.py
@@ -147,14 +147,14 @@ def set_jsversion(version):
         package_json = f.readlines()
     for iline, line in enumerate(package_json):
         if '"version"' in line:
-            package_json[iline] = '  "version": "{}",\n'.format(version)
+            package_json[iline] = f'  "version": "{version}",\n'
     with open(package_json_path, "w") as f:
         f.writelines(package_json)
 
 
 def get_release_notes(version):
     version = normalize_version(version)
-    underline = "=" * len("Version {}".format(version))
+    underline = "=" * len(f"Version {version}")
     initial_message = RELEASE_NOTES_TEMPLATE.format(
         version_string=version, underline=underline
     )
@@ -195,7 +195,7 @@ def normalize_version(version):
 def run(command, **kwargs):
     result = invoke_run(command, hide=True, warn=True, **kwargs)
     if result.exited != 0:
-        error("Error running {}".format(command))
+        error(f"Error running {command}")
         print(result.stdout)
         print()
         print(result.stderr)

--- a/tasks.py
+++ b/tasks.py
@@ -67,7 +67,7 @@ def release(ctx, version):
     run("git add dash_bootstrap_components/_version.py")
     run("git add package.json")
     run(f'git commit -m "Bump version to {version}"')
-    info(f"Tagging version {version}")
+    info(f"Tagging version {version} and pushing to GitHub")
     run('git tag -a "{version}" -F changelog.tmp')
     run("git push origin master --tags")
 


### PR DESCRIPTION
The release process is somewhat involved since 
- there's several version numbers that need to be bumped;
- there are several build steps.

This makes it easy to make mistakes.

This PR adds automation around the release process. With it, it's enough to do:

```
invoke prerelease 0.0.7-rc1
invoke release 0.0.7
invoke postrelease 0.0.7
```

... to do a release.

Most of this is inspired by [gmaps](https://github.com/pbugnion/gmaps/blob/master/tasks.py), which has a similar build chain.

I've tested this on `0.0.7`, but it'd be good to try another release when this is merged to make sure it works correctly.