### PR TITLE
Deploy documentation to Heroku

### DIFF
--- a/docs/Procfile
+++ b/docs/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn run:server

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -20,6 +20,6 @@ This is a set of instructions for releasing to Pypi. The release process is some
 The documentation is currently hosted on Heroku. To push documentation updates:
 
 ```
-git remote add heroku https://git.heroku.com/thawing-hamlet-32470.git
+git remote add heroku https://git.heroku.com/dash-bootstrap-components.git
 git subtree push --prefix docs/ heroku master
 ```

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -14,3 +14,12 @@ This is a set of instructions for releasing to Pypi. The release process is some
  - Verify that the new version is available by running ``pip install dash-bootstrap-components`` in a new virtual environment.
 
  - Run ``invoke postrelease <version>``, where ``version`` is the version number of the new release. This will change the version numbers back to a `-dev` version.
+
+# Releasing documentation changes
+
+The documentation is currently hosted on Heroku. To push documentation updates:
+
+```
+git remote add heroku https://git.heroku.com/thawing-hamlet-32470.git
+git subtree push --prefix docs/ heroku master
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
-dash_html_components
+dash_bootstrap_components
 dash_core_components
+dash_html_components
+gunicorn


### PR DESCRIPTION
This PR adds a Procfile for deploying the documentation to Heroku. 

Heroku seems like a good initial choice for the deployment. We can consider moving to a more custom deployment if the application gets lots of traffic.

The documentation is currently deployed at [https://thawing-hamlet-32470.herokuapp.com/](https://thawing-hamlet-32470.herokuapp.com/).

The next step would be to buy a domain name. I want to do this directly in ASI's AWS account because transferring domain ownership sounds painful, but I need to check with Andy first.

I have just added documentation on deployment through the heroku CLI. If we decide to stick to Heroku, we can (probably) set up an integration with GitHub so that changes are automatically deployed.