### PR TITLE
Adding (text) color attribute to components

### DIFF
--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -18,6 +18,7 @@ const Label = props => {
     align,
     xs,
     className,
+    color,
     ...otherProps
   } = props;
 
@@ -25,7 +26,11 @@ const Label = props => {
   const cols = colWidths.filter(colWidth => props[colWidth] || props[colWidth] === '');
 
   const alignClass = align && alignMap[align];
-  const classes = classNames(className, cols.length && alignClass);
+  const classes = classNames(
+    className,
+    cols.length && alignClass,
+    color && `text-${color}`
+  );
 
   return (<RSLabel for={html_for} xs={xs || width} className={classes} {...otherProps}>
     {children}
@@ -112,6 +117,12 @@ Label.propTypes = {
    * Set vertical alignement of the label, default: `center`
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
+
+  /**
+   * Text color, options: primary, secondary, success, warning, danger, info,
+   * muted, light, dark, body, white, black-50, white-50.
+   */
+  color: PropTypes.string
 };
 
 Label.defaultProps = {

--- a/src/components/card/CardSubtitle.js
+++ b/src/components/card/CardSubtitle.js
@@ -1,12 +1,16 @@
 import PropTypes from 'prop-types';
 import {CardSubtitle as RSCardSubtitle} from 'reactstrap';
+import classNames from 'classnames';
 
 const CardSubtitle = props => {
   const {
     children,
+    className,
+    color,
     ...otherProps
   } = props;
-  return (<RSCardSubtitle {...otherProps}>
+  const classes = classNames(className, color && `text-${color}`);
+  return (<RSCardSubtitle className={classes} {...otherProps}>
     {children}
   </RSCardSubtitle>);
 }
@@ -37,7 +41,13 @@ CardSubtitle.propTypes = {
   /**
    * HTML tag to use for the card subtitle, default: h6
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Text color, options: primary, secondary, success, warning, danger, info,
+   * muted, light, dark, body, white, black-50, white-50.
+   */
+  color: PropTypes.string
 }
 
 export default CardSubtitle;

--- a/src/components/card/CardText.js
+++ b/src/components/card/CardText.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {CardText as RSCardText} from 'reactstrap';
+import classNames from 'classnames';
 
 const CardText = props => {
   const {
     children,
+    className,
+    color,
     ...otherProps
   } = props;
-  return (<RSCardText {...otherProps}>
+  const classes = classNames(className, color && `text-${color}`);
+  return (<RSCardText className={classes} {...otherProps}>
     {children}
   </RSCardText>);
 }
@@ -38,7 +42,13 @@ CardText.propTypes = {
   /**
    * HTML tag to use for the card text, default: p
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Text color, options: primary, secondary, success, warning, danger, info,
+   * muted, light, dark, body, white, black-50, white-50.
+   */
+  color: PropTypes.string
 }
 
 export default CardText;

--- a/src/components/card/CardTitle.js
+++ b/src/components/card/CardTitle.js
@@ -1,12 +1,16 @@
 import PropTypes from 'prop-types';
 import {CardTitle as RSCardTitle} from 'reactstrap';
+import classNames from 'classnames';
 
 const CardTitle = props => {
   const {
     children,
+    className,
+    color,
     ...otherProps
   } = props;
-  return (<RSCardTitle {...otherProps}>
+  const classes = classNames(className, color && `text-${color}`);
+  return (<RSCardTitle className={classes} {...otherProps}>
     {children}
   </RSCardTitle>);
 }
@@ -37,7 +41,13 @@ CardTitle.propTypes = {
   /**
    * HTML tag to use for the card body, default: h5
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Text color, options: primary, secondary, success, warning, danger, info,
+   * muted, light, dark, body, white, black-50, white-50.
+   */
+  color: PropTypes.string
 }
 
 export default CardTitle;

--- a/src/components/listgroup/ListGroupItemText.js
+++ b/src/components/listgroup/ListGroupItemText.js
@@ -1,12 +1,16 @@
 import PropTypes from 'prop-types';
 import {ListGroupItemText as RSListGroupItemText} from 'reactstrap';
+import classNames from 'classnames';
 
 const ListGroupItemText = props => {
   const {
     children,
+    className,
+    color,
     ...otherProps
   } = props;
-  return (<RSListGroupItemText {...otherProps}>
+  const classes = classNames(className, color && `text-${color}`);
+  return (<RSListGroupItemText className={classes} {...otherProps}>
     {children}
   </RSListGroupItemText>);
 }
@@ -37,7 +41,13 @@ ListGroupItemText.propTypes = {
   /**
    * HTML tag to use for the text, default: p
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Text color, options: primary, secondary, success, warning, danger, info,
+   * muted, light, dark, body, white, black-50, white-50.
+   */
+  color: PropTypes.string
 }
 
 export default ListGroupItemText;


### PR DESCRIPTION
This small PR adds text color to the python interface for `Label`, `CardTitle`, `CardSubtitle`, `CardText` and `ListGroupItemText`.