### PR TITLE
Update activeTab prop

### DIFF
--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -1,6 +1,7 @@
 import dash
 import dash_bootstrap_components as dbc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 app = dash.Dash()
 
@@ -31,10 +32,17 @@ app.layout = dbc.Container(
             [
                 dbc.Tab(tab1_content, label="Tab 1"),
                 dbc.Tab(tab2_content, label="Tab 2"),
-            ]
+            ],
+            id="tabs",
         ),
+        html.Div(id="active-tab")
     ]
 )
+
+
+@app.callback(Output("active-tab", "children"), [Input("tabs", "activeTab")])
+def foo(at):
+    return at
 
 
 if __name__ == "__main__":

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -41,6 +41,9 @@ class Tabs extends React.Component {
   toggle(tab) {
     if (this.state.activeTab !== tab) {
       this.setState({activeTab: tab});
+      if (this.props.setProps) {
+        this.props.setProps({activeTab: tab});
+      }
     }
   }
 


### PR DESCRIPTION
Previously `Tabs` would only update it's state when toggling between tabs, which meant it was not possible to use the `activeTab` prop in Dash callbacks.

This PR resolves that issue by updating the `activeTab` prop when tabs are toggled.