### PR TITLE
Document layout rebased

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1,91 +1,90 @@
-
 .main-header {
-    background-color: white;
+  background-color: white;
 }
 
 .main-header h1 {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 .main-header p.lead {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .main-header .btn {
-    margin-right: 1rem;
+  margin-right: 1rem;
 }
 
-.main-header .btn + .btn {
-    margin-right: 0;
+.main-header .btn+.btn {
+  margin-right: 0;
 }
 
 .section-header {
-    font-weight: 300;
+  font-weight: 300;
 }
 
 code.hljs {
-    padding: 1em;
-    border-radius: 3px;
+  padding: 1em;
+  border-radius: 3px;
 }
 
 span.hljs-meta {
-    color: #66d9ef;
+  color: #66d9ef;
 }
 
 .demo-layout-container {
-    height: 600px;
-    margin-right: 0rem;
-    margin-left: 0rem;
-    margin-bottom: 3rem;
-    margin-top: 2rem;
-    display: block;
-    box-shadow: 0 0 60px rgba(0, 0, 0, 0.3);
-    border-radius: 6px;
-    overflow: none;
+  height: 600px;
+  margin-right: 0rem;
+  margin-left: 0rem;
+  margin-bottom: 3rem;
+  margin-top: 2rem;
+  display: block;
+  box-shadow: 0 0 60px rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  overflow: none;
 }
 
 .demo-layout {
-    width: 100%;
-    height: 100%;
-    display: block;
-    border: 0;
-    border-radius: 6px;
+  width: 100%;
+  height: 100%;
+  display: block;
+  border: 0;
+  border-radius: 6px;
 }
 
 .docs-content {
-    margin-top: 2rem;
+  margin-top: 2rem;
 }
 
 .docs-sidebar .nav-item {
-    padding: 0 .2rem 0 .2rem;
+  padding: 0 .2rem 0 .2rem;
 }
 
 .docs-sidebar .nav-link {
-    color: #888;
-    padding: .3rem .5rem .3rem 1rem;
-    border-left: 2px solid transparent;
+  color: #888;
+  padding: .3rem .5rem .3rem 1rem;
+  border-left: 2px solid transparent;
 }
 
 .docs-sidebar .nav-link:hover {
-    color: #777;
-    border-left: 2px solid #aaa;
+  color: #777;
+  border-left: 2px solid #aaa;
 }
 
 .docs-sidebar .nav-link.active {
-    color: #666;
-    border-left: 2px solid #d9534f;
+  color: #666;
+  border-left: 2px solid #d9534f;
 }
 
 .docs-sidebar .nav-link.active:hover {
-    border-left: 2px solid #d9534f;
+  border-left: 2px solid #d9534f;
 }
 
 .example-container {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 .example-source-container {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .api-documentation {
@@ -94,18 +93,14 @@ span.hljs-meta {
 
 .layout-demo .row {
   margin-bottom: 10px;
-  background: linear-gradient(
-      to right,
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, 0) calc(100% - 15px),
-      #fff calc(100% - 15px)
-    ),
-    linear-gradient(
-      to right,
-      #fff,
-      #fff 15px,
-      rgba(0, 0, 0, 0) 15px
-    ),
+  background: linear-gradient(to right,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0) calc(100% - 15px),
+    #fff calc(100% - 15px)),
+    linear-gradient(to right,
+    #fff,
+    #fff 15px,
+    rgba(0, 0, 0, 0) 15px),
     linear-gradient(to right, #eeeeee, #eeeeee);
 }
 
@@ -113,13 +108,12 @@ span.hljs-meta {
   background: linear-gradient(to right, #eeeeee, #eeeeee);
 }
 
-
 .layout-demo .pad-row .row {
   height: 100px;
 }
 
 .layout-demo .col>div, .layout-demo [class*="col-"]>div {
   padding: 0.75rem;
-  background-color: rgba(86,61,124,.15);
-  border: 1px solid rgba(86,61,124,.2);
+  background-color: rgba(86, 61, 124, .15);
+  border: 1px solid rgba(86, 61, 124, .2);
 }

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -101,7 +101,7 @@ span.hljs-meta {
   height: 100px;
 }
 
-.layout-demo .col>div {
+.layout-demo .col>div, .layout-demo [class*="col-"]>div {
   padding: 0.75rem;
   background-color: rgba(86,61,124,.15);
   border: 1px solid rgba(86,61,124,.2);

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -95,6 +95,19 @@ span.hljs-meta {
 .layout-demo .row {
   /* background-color: rgba(255,0,0,.1); */
   margin-bottom: 10px;
+  background: linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0) calc(100% - 15px),
+      #fff calc(100% - 15px)
+    ),
+    linear-gradient(
+      to right,
+      #fff,
+      #fff 15px,
+      rgba(0, 0, 0, 0) 15px
+    ),
+    linear-gradient(to right, #eeeeee, #eeeeee);
 }
 
 .layout-demo.pad-row .row {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -93,7 +93,6 @@ span.hljs-meta {
 }
 
 .layout-demo .row {
-  /* background-color: rgba(255,0,0,.1); */
   margin-bottom: 10px;
   background: linear-gradient(
       to right,

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -89,5 +89,20 @@ span.hljs-meta {
 }
 
 .api-documentation {
-    margin-bottom: 4rem;
+  margin-bottom: 4rem;
+}
+
+.layout-demo .row {
+  /* background-color: rgba(255,0,0,.1); */
+  margin-bottom: 10px;
+}
+
+.layout-demo.pad-row .row {
+  height: 100px;
+}
+
+.layout-demo .col>div {
+  padding: 0.75rem;
+  background-color: rgba(86,61,124,.15);
+  border: 1px solid rgba(86,61,124,.2);
 }

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -110,6 +110,11 @@ span.hljs-meta {
     linear-gradient(to right, #eeeeee, #eeeeee);
 }
 
+.layout-demo .row.no-gutters {
+  background: linear-gradient(to right, #eeeeee, #eeeeee);
+}
+
+
 .layout-demo.pad-row .row {
   height: 100px;
 }

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -115,7 +115,7 @@ span.hljs-meta {
 }
 
 
-.layout-demo.pad-row .row {
+.layout-demo .pad-row .row {
   height: 100px;
 }
 

--- a/docs/components_page/components/layout/breakpoints.py
+++ b/docs/components_page/components/layout/breakpoints.py
@@ -1,0 +1,21 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Specify width for different screen sizes"),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns"), md=4),
+                dbc.Col(html.Div("One of three columns"), md=4),
+                dbc.Col(html.Div("One of three columns"), md=4),
+            ]
+        ),
+        dbc.Row([
+            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+        ])
+    ]
+)

--- a/docs/components_page/components/layout/breakpoints.py
+++ b/docs/components_page/components/layout/breakpoints.py
@@ -11,11 +11,13 @@ row = html.Div(
                 dbc.Col(html.Div("One of three columns"), md=4),
             ]
         ),
-        dbc.Row([
-            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
-            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
-            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
-            dbc.Col(html.Div("One of four columns"), width=6, lg=3),
-        ])
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+                dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+                dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+                dbc.Col(html.Div("One of four columns"), width=6, lg=3),
+            ]
+        ),
     ]
 )

--- a/docs/components_page/components/layout/horizontal.py
+++ b/docs/components_page/components/layout/horizontal.py
@@ -1,0 +1,43 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Horizontal alignment"),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of two columns"), width=4),
+                dbc.Col(html.Div("One of two columns"), width=4),
+            ],
+            justify="start",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of two columns"), width=4),
+                dbc.Col(html.Div("One of two columns"), width=4),
+            ],
+            justify="center",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of two columns"), width=4),
+                dbc.Col(html.Div("One of two columns"), width=4),
+            ],
+            justify="end",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of two columns"), width=4),
+                dbc.Col(html.Div("One of two columns"), width=4),
+            ],
+            justify="between",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of two columns"), width=4),
+                dbc.Col(html.Div("One of two columns"), width=4),
+            ],
+            justify="around",
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/no_gutters.py
+++ b/docs/components_page/components/layout/no_gutters.py
@@ -1,0 +1,16 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Row without 'gutters'"),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+            ],
+            noGutters=True,
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/order_offset.py
+++ b/docs/components_page/components/layout/order_offset.py
@@ -1,0 +1,30 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Specify order and offset"),
+        dbc.Row(
+            dbc.Col(
+                html.Div("A single, half-width column"),
+                width={"size": 6, "offset": 3},
+            )
+        ),
+        dbc.Row(
+            [
+                dbc.Col(
+                    html.Div("The last of three columns"),
+                    width={"size": 3, "order": "last", "offset": 1},
+                ),
+                dbc.Col(
+                    html.Div("The first of three columns"),
+                    width={"size": 3, "order": 1, "offset": 2},
+                ),
+                dbc.Col(
+                    html.Div("The second of three columns"),
+                    width={"size": 3, "order": 12},
+                ),
+            ]
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/simple.py
+++ b/docs/components_page/components/layout/simple.py
@@ -1,0 +1,16 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H2("Row with columns"),
+        dbc.Row(dbc.Col(html.Div("A single column"))),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+            ]
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/vertical.py
+++ b/docs/components_page/components/layout/vertical.py
@@ -1,0 +1,39 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Vertical alignment"),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+            ],
+            align="start",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+            ],
+            align="center",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns")),
+            ],
+            align="end",
+        ),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns"), align="start"),
+                dbc.Col(html.Div("One of three columns"), align="center"),
+                dbc.Col(html.Div("One of three columns"), align="end"),
+            ]
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/width.py
+++ b/docs/components_page/components/layout/width.py
@@ -1,0 +1,16 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+row = html.Div(
+    [
+        html.H4("Specify width"),
+        dbc.Row(dbc.Col(html.Div("A single, half-width column"), width=6)),
+        dbc.Row(
+            [
+                dbc.Col(html.Div("One of three columns"), width=3),
+                dbc.Col(html.Div("One of three columns")),
+                dbc.Col(html.Div("One of three columns"), width=3),
+            ]
+        ),
+    ]
+)

--- a/docs/components_page/components/layout/width.py
+++ b/docs/components_page/components/layout/width.py
@@ -6,6 +6,9 @@ row = html.Div(
         html.H4("Specify width"),
         dbc.Row(dbc.Col(html.Div("A single, half-width column"), width=6)),
         dbc.Row(
+            dbc.Col(html.Div("An automatically sized column"), width="auto")
+        ),
+        dbc.Row(
             [
                 dbc.Col(html.Div("One of three columns"), width=3),
                 dbc.Col(html.Div("One of three columns")),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 
 from .components.alerts import alerts
 from .components.badges import badges
 from .components.buttons.simple import buttons as buttons_simple
 from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.group import buttons as buttons_group
+from .components.layout.simple import row as layout_simple
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -43,6 +45,7 @@ sidebar_entries = [
     SidebarEntry("badges", "Badges"),
     SidebarEntry("buttons", "Buttons"),
     SidebarEntry("collapse", "Collapse"),
+    SidebarEntry("layout", "Layout"),
 ]
 
 
@@ -94,6 +97,10 @@ class ComponentsPage:
                 HighlightedSource(collapse_source),
                 ApiDoc(component_metadata.get("src/components/Collapse.js")),
             ],
+            "layout": html.Div(
+                [layout_simple, HighlightedSource(layout_simple_source)],
+                className="layout-demo",
+            ),
         }
 
     def for_path(self, path_components):

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -11,6 +11,7 @@ from .components.buttons.group import buttons as buttons_group
 from .components.layout.simple import row as layout_simple
 from .components.layout.width import row as layout_width
 from .components.layout.order_offset import row as layout_order_offset
+from .components.layout.breakpoints import row as layout_breakpoints
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -36,6 +37,9 @@ layout_simple_source = (COMPONENTS / "layout" / "simple.py").open().read()
 layout_width_source = (COMPONENTS / "layout" / "width.py").open().read()
 layout_order_offset_source = (
     (COMPONENTS / "layout" / "order_offset.py").open().read()
+)
+layout_breakpoints_source = (
+    (COMPONENTS / "layout" / "breakpoints.py").open().read()
 )
 
 NAVBAR = dbc.Navbar(
@@ -112,6 +116,8 @@ class ComponentsPage:
                     HighlightedSource(layout_width_source),
                     layout_order_offset,
                     HighlightedSource(layout_order_offset_source),
+                    layout_breakpoints,
+                    HighlightedSource(layout_breakpoints_source)
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -139,6 +139,8 @@ class ComponentsPage:
                     ),
                     layout_horizontal,
                     HighlightedSource(layout_horizontal_source),
+                    ApiDoc(component_metadata.get("src/components/layout/Row.js")),
+                    ApiDoc(component_metadata.get("src/components/layout/Col.js")),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -13,6 +13,7 @@ from .components.layout.width import row as layout_width
 from .components.layout.order_offset import row as layout_order_offset
 from .components.layout.breakpoints import row as layout_breakpoints
 from .components.layout.no_gutters import row as layout_no_gutters
+from .components.layout.vertical import row as layout_vertical
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -45,6 +46,7 @@ layout_breakpoints_source = (
 layout_no_gutters_source = (
     (COMPONENTS / "layout" / "no_gutters.py").open().read()
 )
+layout_vertical_source = (COMPONENTS / "layout" / "vertical.py").open().read()
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -124,6 +126,13 @@ class ComponentsPage:
                     HighlightedSource(layout_breakpoints_source),
                     layout_no_gutters,
                     HighlightedSource(layout_no_gutters_source),
+                    html.Div(
+                        [
+                            layout_vertical,
+                            HighlightedSource(layout_vertical_source),
+                        ],
+                        className="pad-row",
+                    ),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -10,6 +10,7 @@ from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.group import buttons as buttons_group
 from .components.layout.simple import row as layout_simple
 from .components.layout.width import row as layout_width
+from .components.layout.order_offset import row as layout_order_offset
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -33,6 +34,9 @@ buttons_outline_source = (COMPONENTS / "buttons" / "outline.py").open().read()
 buttons_group_source = (COMPONENTS / "buttons" / "group.py").open().read()
 layout_simple_source = (COMPONENTS / "layout" / "simple.py").open().read()
 layout_width_source = (COMPONENTS / "layout" / "width.py").open().read()
+layout_order_offset_source = (
+    (COMPONENTS / "layout" / "order_offset.py").open().read()
+)
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -106,6 +110,8 @@ class ComponentsPage:
                     HighlightedSource(layout_simple_source),
                     layout_width,
                     HighlightedSource(layout_width_source),
+                    layout_order_offset,
+                    HighlightedSource(layout_order_offset_source),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -12,6 +12,7 @@ from .components.layout.simple import row as layout_simple
 from .components.layout.width import row as layout_width
 from .components.layout.order_offset import row as layout_order_offset
 from .components.layout.breakpoints import row as layout_breakpoints
+from .components.layout.no_gutters import row as layout_no_gutters
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -40,6 +41,9 @@ layout_order_offset_source = (
 )
 layout_breakpoints_source = (
     (COMPONENTS / "layout" / "breakpoints.py").open().read()
+)
+layout_no_gutters_source = (
+    (COMPONENTS / "layout" / "no_gutters.py").open().read()
 )
 
 NAVBAR = dbc.Navbar(
@@ -117,7 +121,9 @@ class ComponentsPage:
                     layout_order_offset,
                     HighlightedSource(layout_order_offset_source),
                     layout_breakpoints,
-                    HighlightedSource(layout_breakpoints_source)
+                    HighlightedSource(layout_breakpoints_source),
+                    layout_no_gutters,
+                    HighlightedSource(layout_no_gutters_source),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -5,16 +5,16 @@ import dash_html_components as html
 
 from .components.alerts import alerts
 from .components.badges import badges
-from .components.buttons.simple import buttons as buttons_simple
-from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.group import buttons as buttons_group
-from .components.layout.simple import row as layout_simple
-from .components.layout.width import row as layout_width
-from .components.layout.order_offset import row as layout_order_offset
+from .components.buttons.outline import buttons as buttons_outline
+from .components.buttons.simple import buttons as buttons_simple
 from .components.layout.breakpoints import row as layout_breakpoints
-from .components.layout.no_gutters import row as layout_no_gutters
-from .components.layout.vertical import row as layout_vertical
 from .components.layout.horizontal import row as layout_horizontal
+from .components.layout.no_gutters import row as layout_no_gutters
+from .components.layout.order_offset import row as layout_order_offset
+from .components.layout.simple import row as layout_simple
+from .components.layout.vertical import row as layout_vertical
+from .components.layout.width import row as layout_width
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -139,8 +139,12 @@ class ComponentsPage:
                     ),
                     layout_horizontal,
                     HighlightedSource(layout_horizontal_source),
-                    ApiDoc(component_metadata.get("src/components/layout/Row.js")),
-                    ApiDoc(component_metadata.get("src/components/layout/Col.js")),
+                    ApiDoc(
+                        component_metadata.get("src/components/layout/Row.js")
+                    ),
+                    ApiDoc(
+                        component_metadata.get("src/components/layout/Col.js")
+                    ),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -14,6 +14,7 @@ from .components.layout.order_offset import row as layout_order_offset
 from .components.layout.breakpoints import row as layout_breakpoints
 from .components.layout.no_gutters import row as layout_no_gutters
 from .components.layout.vertical import row as layout_vertical
+from .components.layout.horizontal import row as layout_horizontal
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -47,6 +48,9 @@ layout_no_gutters_source = (
     (COMPONENTS / "layout" / "no_gutters.py").open().read()
 )
 layout_vertical_source = (COMPONENTS / "layout" / "vertical.py").open().read()
+layout_horizontal_source = (
+    (COMPONENTS / "layout" / "horizontal.py").open().read()
+)
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -133,6 +137,8 @@ class ComponentsPage:
                         ],
                         className="pad-row",
                     ),
+                    layout_horizontal,
+                    HighlightedSource(layout_horizontal_source),
                 ],
                 className="layout-demo",
             ),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -9,6 +9,7 @@ from .components.buttons.simple import buttons as buttons_simple
 from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.group import buttons as buttons_group
 from .components.layout.simple import row as layout_simple
+from .components.layout.width import row as layout_width
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -30,6 +31,8 @@ buttons_simple_source = (COMPONENTS / "buttons" / "simple.py").open().read()
 buttons_usage_source = (COMPONENTS / "buttons" / "usage.py").open().read()
 buttons_outline_source = (COMPONENTS / "buttons" / "outline.py").open().read()
 buttons_group_source = (COMPONENTS / "buttons" / "group.py").open().read()
+layout_simple_source = (COMPONENTS / "layout" / "simple.py").open().read()
+layout_width_source = (COMPONENTS / "layout" / "width.py").open().read()
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -98,7 +101,12 @@ class ComponentsPage:
                 ApiDoc(component_metadata.get("src/components/Collapse.js")),
             ],
             "layout": html.Div(
-                [layout_simple, HighlightedSource(layout_simple_source)],
+                [
+                    layout_simple,
+                    HighlightedSource(layout_simple_source),
+                    layout_width,
+                    HighlightedSource(layout_width_source),
+                ],
                 className="layout-demo",
             ),
         }

--- a/docs/components_page/sidebar.py
+++ b/docs/components_page/sidebar.py
@@ -1,7 +1,7 @@
+from typing import NamedTuple
+
 import dash_bootstrap_components as dbc
 import dash_html_components as html
-
-from typing import NamedTuple
 
 
 class SidebarEntry(NamedTuple):


### PR DESCRIPTION
This PR is equivalent to PR #29 , but I have rebased it to avoid re-committing commits e00bddb, 595227d and 73f37de9. The commits to fix the rebase (f04bb7f1be3 and a7752bb80) then naturally drop out. This may come across as fairly pedantic, but I think it makes it somewhat easier to maintain.

Apart from resulting in nicer looking commit graphs, a cleaner history makes it:
- easier to run git bisect to understand where regressions were introduced
- easier to understand the scope of changes in a given PR.

Tom -- those commits are now listed with you as the author and me as the committer -- while GitHub recognizes the difference, most programs that show history just show the author.

Deployed [here](https://dash-bootstrap-components-documentation.app.asi.sherlockml.net/l/components/layout).

If you're happy that this has everything, I suggest that I force push this branch back onto the original PR.