### PR TITLE
Refactor creating the layout for the content of each component

### DIFF
--- a/docs/components_page/alerts_content.py
+++ b/docs/components_page/alerts_content.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from .helpers import ExampleContainer, HighlightedSource
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+from .components.alerts import alerts
+
+
+HERE = Path(__file__).parent
+
+source = (HERE / "components" / "alerts.py").open().read()
+
+
+content = [
+    ExampleContainer(alerts),
+    HighlightedSource(source),
+    ApiDoc(get_component_metadata("src/components/Alert.js")),
+]

--- a/docs/components_page/badges_content.py
+++ b/docs/components_page/badges_content.py
@@ -1,0 +1,18 @@
+
+from pathlib import Path
+
+from .components.badges import badges
+from .helpers import ExampleContainer, HighlightedSource
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+
+
+HERE = Path(__file__).parent
+
+badges_source = (HERE / "components" / "badges.py").open().read()
+
+content = [
+    ExampleContainer(badges),
+    HighlightedSource(badges_source),
+    ApiDoc(get_component_metadata("src/components/Badge.js")),
+]

--- a/docs/components_page/badges_content.py
+++ b/docs/components_page/badges_content.py
@@ -10,6 +10,7 @@ HERE = Path(__file__).parent
 
 badges_source = (HERE / "components" / "badges.py").open().read()
 
+
 content = [
     ExampleContainer(badges),
     HighlightedSource(badges_source),

--- a/docs/components_page/badges_content.py
+++ b/docs/components_page/badges_content.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 
 from .components.badges import badges

--- a/docs/components_page/buttons_content.py
+++ b/docs/components_page/buttons_content.py
@@ -23,9 +23,7 @@ def get_content(app):
         ExampleContainer(buttons_simple),
         HighlightedSource(buttons_simple_source),
         ExampleContainer(
-            load_source_with_app(
-                app, buttons_usage_source, "button"
-            )
+            load_source_with_app(app, buttons_usage_source, "button")
         ),
         HighlightedSource(buttons_usage_source),
         ExampleContainer(buttons_outline),

--- a/docs/components_page/buttons_content.py
+++ b/docs/components_page/buttons_content.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+
+from .components.buttons.group import buttons as buttons_group
+from .components.buttons.outline import buttons as buttons_outline
+from .components.buttons.simple import buttons as buttons_simple
+
+
+HERE = Path(__file__).parent
+BUTTONS = HERE / "components" / "buttons"
+
+buttons_simple_source = (BUTTONS / "simple.py").open().read()
+buttons_usage_source = (BUTTONS / "usage.py").open().read()
+buttons_outline_source = (BUTTONS / "outline.py").open().read()
+buttons_group_source = (BUTTONS / "group.py").open().read()
+
+
+def get_content(app):
+    return [
+        ExampleContainer(buttons_simple),
+        HighlightedSource(buttons_simple_source),
+        ExampleContainer(
+            load_source_with_app(
+                app, buttons_usage_source, "button"
+            )
+        ),
+        HighlightedSource(buttons_usage_source),
+        ExampleContainer(buttons_outline),
+        HighlightedSource(buttons_outline_source),
+        ExampleContainer(buttons_group),
+        HighlightedSource(buttons_group_source),
+        ApiDoc(get_component_metadata("src/components/Button.js")),
+    ]

--- a/docs/components_page/cards_content.py
+++ b/docs/components_page/cards_content.py
@@ -14,9 +14,7 @@ HERE = Path(__file__).parent
 CARDS = HERE / "components" / "cards"
 
 cards_simple_source = (CARDS / "simple.py").open().read()
-cards_content_type_source = (
-    (CARDS / "content_types.py").open().read()
-)
+cards_content_type_source = (CARDS / "content_types.py").open().read()
 cards_group_source = (CARDS / "group.py").open().read()
 cards_columns_source = (CARDS / "columns.py").open().read()
 
@@ -39,9 +37,7 @@ content = [
         component_name="CardGroup",
     ),
     ApiDoc(
-        get_component_metadata(
-            "src/components/card/CardColumns.js"
-        ),
+        get_component_metadata("src/components/card/CardColumns.js"),
         component_name="CardColumns",
     ),
     ApiDoc(
@@ -49,9 +45,7 @@ content = [
         component_name="Card",
     ),
     ApiDoc(
-        get_component_metadata(
-            "src/components/card/CardHeader.js"
-        ),
+        get_component_metadata("src/components/card/CardHeader.js"),
         component_name="CardHeader",
     ),
     ApiDoc(
@@ -59,9 +53,7 @@ content = [
         component_name="CardBody",
     ),
     ApiDoc(
-        get_component_metadata(
-            "src/components/card/CardFooter.js"
-        ),
+        get_component_metadata("src/components/card/CardFooter.js"),
         component_name="CardFooter",
     ),
     ApiDoc(
@@ -69,9 +61,7 @@ content = [
         component_name="CardTitle",
     ),
     ApiDoc(
-        get_component_metadata(
-            "src/components/card/CardSubtitle.js"
-        ),
+        get_component_metadata("src/components/card/CardSubtitle.js"),
         component_name="CardSubtitle",
     ),
     ApiDoc(
@@ -83,9 +73,7 @@ content = [
         component_name="CardImg",
     ),
     ApiDoc(
-        get_component_metadata(
-            "src/components/card/CardImgOverlay.js"
-        ),
+        get_component_metadata("src/components/card/CardImgOverlay.js"),
         component_name="CardImgOverlay",
     ),
 ]

--- a/docs/components_page/cards_content.py
+++ b/docs/components_page/cards_content.py
@@ -19,7 +19,7 @@ cards_content_type_source = (
 cards_group_source = (CARDS / "group.py").open().read()
 cards_columns_source = (CARDS / "columns.py").open().read()
 
-page = [
+content = [
     ExampleContainer(cards_simple),
     HighlightedSource(cards_simple_source),
     ExampleContainer(cards_content_types),

--- a/docs/components_page/cards_content.py
+++ b/docs/components_page/cards_content.py
@@ -9,6 +9,7 @@ from .components.cards.content_types import cards as cards_content_types
 from .components.cards.group import cards as cards_group
 from .components.cards.columns import cards as cards_columns
 
+
 HERE = Path(__file__).parent
 CARDS = HERE / "components" / "cards"
 
@@ -18,6 +19,7 @@ cards_content_type_source = (
 )
 cards_group_source = (CARDS / "group.py").open().read()
 cards_columns_source = (CARDS / "columns.py").open().read()
+
 
 content = [
     ExampleContainer(cards_simple),

--- a/docs/components_page/cards_page.py
+++ b/docs/components_page/cards_page.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from .helpers import ExampleContainer, HighlightedSource
 from .api_doc import ApiDoc
-from .metadata import load_metadata
+from .metadata import get_component_metadata
 
 from .components.cards.simple import cards as cards_simple
 from .components.cards.content_types import cards as cards_content_types
@@ -19,8 +19,6 @@ cards_content_type_source = (
 cards_group_source = (CARDS / "group.py").open().read()
 cards_columns_source = (CARDS / "columns.py").open().read()
 
-component_metadata = load_metadata()
-
 page = [
     ExampleContainer(cards_simple),
     HighlightedSource(cards_simple_source),
@@ -31,59 +29,59 @@ page = [
     ExampleContainer(cards_columns),
     HighlightedSource(cards_columns_source),
     ApiDoc(
-        component_metadata.get("src/components/card/CardDeck.js"),
+        get_component_metadata("src/components/card/CardDeck.js"),
         component_name="CardDeck",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/CardGroup.js"),
+        get_component_metadata("src/components/card/CardGroup.js"),
         component_name="CardGroup",
     ),
     ApiDoc(
-        component_metadata.get(
+        get_component_metadata(
             "src/components/card/CardColumns.js"
         ),
         component_name="CardColumns",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/Card.js"),
+        get_component_metadata("src/components/card/Card.js"),
         component_name="Card",
     ),
     ApiDoc(
-        component_metadata.get(
+        get_component_metadata(
             "src/components/card/CardHeader.js"
         ),
         component_name="CardHeader",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/CardBody.js"),
+        get_component_metadata("src/components/card/CardBody.js"),
         component_name="CardBody",
     ),
     ApiDoc(
-        component_metadata.get(
+        get_component_metadata(
             "src/components/card/CardFooter.js"
         ),
         component_name="CardFooter",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/CardTitle.js"),
+        get_component_metadata("src/components/card/CardTitle.js"),
         component_name="CardTitle",
     ),
     ApiDoc(
-        component_metadata.get(
+        get_component_metadata(
             "src/components/card/CardSubtitle.js"
         ),
         component_name="CardSubtitle",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/CardLink.js"),
+        get_component_metadata("src/components/card/CardLink.js"),
         component_name="CardLink",
     ),
     ApiDoc(
-        component_metadata.get("src/components/card/CardImg.js"),
+        get_component_metadata("src/components/card/CardImg.js"),
         component_name="CardImg",
     ),
     ApiDoc(
-        component_metadata.get(
+        get_component_metadata(
             "src/components/card/CardImgOverlay.js"
         ),
         component_name="CardImgOverlay",

--- a/docs/components_page/cards_page.py
+++ b/docs/components_page/cards_page.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from .helpers import ExampleContainer, HighlightedSource
+from .api_doc import ApiDoc
+from .metadata import load_metadata
+
+from .components.cards.simple import cards as cards_simple
+from .components.cards.content_types import cards as cards_content_types
+from .components.cards.group import cards as cards_group
+from .components.cards.columns import cards as cards_columns
+
+HERE = Path(__file__).parent
+CARDS = HERE / "components" / "cards"
+
+cards_simple_source = (CARDS / "simple.py").open().read()
+cards_content_type_source = (
+    (CARDS / "content_types.py").open().read()
+)
+cards_group_source = (CARDS / "group.py").open().read()
+cards_columns_source = (CARDS / "columns.py").open().read()
+
+component_metadata = load_metadata()
+
+page = [
+    ExampleContainer(cards_simple),
+    HighlightedSource(cards_simple_source),
+    ExampleContainer(cards_content_types),
+    HighlightedSource(cards_content_type_source),
+    ExampleContainer(cards_group),
+    HighlightedSource(cards_group_source),
+    ExampleContainer(cards_columns),
+    HighlightedSource(cards_columns_source),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardDeck.js"),
+        component_name="CardDeck",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardGroup.js"),
+        component_name="CardGroup",
+    ),
+    ApiDoc(
+        component_metadata.get(
+            "src/components/card/CardColumns.js"
+        ),
+        component_name="CardColumns",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/Card.js"),
+        component_name="Card",
+    ),
+    ApiDoc(
+        component_metadata.get(
+            "src/components/card/CardHeader.js"
+        ),
+        component_name="CardHeader",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardBody.js"),
+        component_name="CardBody",
+    ),
+    ApiDoc(
+        component_metadata.get(
+            "src/components/card/CardFooter.js"
+        ),
+        component_name="CardFooter",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardTitle.js"),
+        component_name="CardTitle",
+    ),
+    ApiDoc(
+        component_metadata.get(
+            "src/components/card/CardSubtitle.js"
+        ),
+        component_name="CardSubtitle",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardLink.js"),
+        component_name="CardLink",
+    ),
+    ApiDoc(
+        component_metadata.get("src/components/card/CardImg.js"),
+        component_name="CardImg",
+    ),
+    ApiDoc(
+        component_metadata.get(
+            "src/components/card/CardImgOverlay.js"
+        ),
+        component_name="CardImgOverlay",
+    ),
+]

--- a/docs/components_page/collapse_content.py
+++ b/docs/components_page/collapse_content.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+
+
+HERE = Path(__file__).parent
+
+collapse_source = (HERE / "components" / "collapse.py").open().read()
+
+
+def get_content(app):
+    return [
+        ExampleContainer(
+            load_source_with_app(app, collapse_source, "collapse")
+        ),
+        HighlightedSource(collapse_source),
+        ApiDoc(get_component_metadata("src/components/Collapse.js")),
+    ]

--- a/docs/components_page/layout_content.py
+++ b/docs/components_page/layout_content.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 
 import dash_html_components as html

--- a/docs/components_page/layout_content.py
+++ b/docs/components_page/layout_content.py
@@ -1,0 +1,70 @@
+
+from pathlib import Path
+
+import dash_html_components as html
+
+from .helpers import ExampleContainer, HighlightedSource
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+
+from .components.layout.breakpoints import row as layout_breakpoints
+from .components.layout.horizontal import row as layout_horizontal
+from .components.layout.no_gutters import row as layout_no_gutters
+from .components.layout.order_offset import row as layout_order_offset
+from .components.layout.simple import row as layout_simple
+from .components.layout.vertical import row as layout_vertical
+from .components.layout.width import row as layout_width
+
+
+HERE = Path(__file__).parent
+LAYOUT = HERE / "components" / "layout"
+
+layout_simple_source = (LAYOUT / "simple.py").open().read()
+layout_width_source = (LAYOUT / "width.py").open().read()
+layout_order_offset_source = (
+    (LAYOUT / "order_offset.py").open().read()
+)
+layout_breakpoints_source = (
+    (LAYOUT / "breakpoints.py").open().read()
+)
+layout_no_gutters_source = (
+    (LAYOUT / "no_gutters.py").open().read()
+)
+layout_vertical_source = (LAYOUT / "vertical.py").open().read()
+layout_horizontal_source = (
+    (LAYOUT / "horizontal.py").open().read()
+)
+
+
+content = html.Div(
+    [
+        ExampleContainer(layout_simple),
+        HighlightedSource(layout_simple_source),
+        ExampleContainer(layout_width),
+        HighlightedSource(layout_width_source),
+        ExampleContainer(layout_order_offset),
+        HighlightedSource(layout_order_offset_source),
+        ExampleContainer(layout_breakpoints),
+        HighlightedSource(layout_breakpoints_source),
+        ExampleContainer(layout_no_gutters),
+        HighlightedSource(layout_no_gutters_source),
+        html.Div(
+            [
+                ExampleContainer(layout_vertical),
+                HighlightedSource(layout_vertical_source),
+            ],
+            className="pad-row",
+        ),
+        ExampleContainer(layout_horizontal),
+        HighlightedSource(layout_horizontal_source),
+        ApiDoc(
+            get_component_metadata("src/components/layout/Row.js"),
+            component_name="Row",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/layout/Col.js"),
+            component_name="Col",
+        ),
+    ],
+    className="layout-demo",
+)

--- a/docs/components_page/layout_content.py
+++ b/docs/components_page/layout_content.py
@@ -20,19 +20,11 @@ LAYOUT = HERE / "components" / "layout"
 
 layout_simple_source = (LAYOUT / "simple.py").open().read()
 layout_width_source = (LAYOUT / "width.py").open().read()
-layout_order_offset_source = (
-    (LAYOUT / "order_offset.py").open().read()
-)
-layout_breakpoints_source = (
-    (LAYOUT / "breakpoints.py").open().read()
-)
-layout_no_gutters_source = (
-    (LAYOUT / "no_gutters.py").open().read()
-)
+layout_order_offset_source = (LAYOUT / "order_offset.py").open().read()
+layout_breakpoints_source = (LAYOUT / "breakpoints.py").open().read()
+layout_no_gutters_source = (LAYOUT / "no_gutters.py").open().read()
 layout_vertical_source = (LAYOUT / "vertical.py").open().read()
-layout_horizontal_source = (
-    (LAYOUT / "horizontal.py").open().read()
-)
+layout_horizontal_source = (LAYOUT / "horizontal.py").open().read()
 
 
 content = html.Div(

--- a/docs/components_page/metadata.py
+++ b/docs/components_page/metadata.py
@@ -1,10 +1,17 @@
 import json
+from functools import lru_cache
 import collections
 
 import dash_bootstrap_components as dbc
 
 
-def load_metadata():
+def get_component_metadata(component_path):
+    metadata = _load_metadata()
+    return metadata.get(component_path)
+
+
+@lru_cache(maxsize=1)
+def _load_metadata():
     return _get_metadata(dbc.METADATA_PATH)
 
 

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -8,10 +8,6 @@ from .components.badges import badges
 from .components.buttons.group import buttons as buttons_group
 from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.simple import buttons as buttons_simple
-from .components.cards.simple import cards as cards_simple
-from .components.cards.content_types import cards as cards_content_types
-from .components.cards.group import cards as cards_group
-from .components.cards.columns import cards as cards_columns
 from .components.layout.breakpoints import row as layout_breakpoints
 from .components.layout.horizontal import row as layout_horizontal
 from .components.layout.no_gutters import row as layout_no_gutters
@@ -19,6 +15,7 @@ from .components.layout.order_offset import row as layout_order_offset
 from .components.layout.simple import row as layout_simple
 from .components.layout.vertical import row as layout_vertical
 from .components.layout.width import row as layout_width
+from .cards_page import page as cards_page
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -40,12 +37,6 @@ buttons_simple_source = (COMPONENTS / "buttons" / "simple.py").open().read()
 buttons_usage_source = (COMPONENTS / "buttons" / "usage.py").open().read()
 buttons_outline_source = (COMPONENTS / "buttons" / "outline.py").open().read()
 buttons_group_source = (COMPONENTS / "buttons" / "group.py").open().read()
-cards_simple_source = (COMPONENTS / "cards" / "simple.py").open().read()
-cards_content_type_source = (
-    (COMPONENTS / "cards" / "content_types.py").open().read()
-)
-cards_group_source = (COMPONENTS / "cards" / "group.py").open().read()
-cards_columns_source = (COMPONENTS / "cards" / "columns.py").open().read()
 layout_simple_source = (COMPONENTS / "layout" / "simple.py").open().read()
 layout_width_source = (COMPONENTS / "layout" / "width.py").open().read()
 layout_order_offset_source = (
@@ -120,74 +111,7 @@ class ComponentsPage:
                 HighlightedSource(buttons_group_source),
                 ApiDoc(component_metadata.get("src/components/Button.js")),
             ],
-            "cards": [
-                ExampleContainer(cards_simple),
-                HighlightedSource(cards_simple_source),
-                ExampleContainer(cards_content_types),
-                HighlightedSource(cards_content_type_source),
-                ExampleContainer(cards_group),
-                HighlightedSource(cards_group_source),
-                ExampleContainer(cards_columns),
-                HighlightedSource(cards_columns_source),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardDeck.js"),
-                    component_name="CardDeck",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardGroup.js"),
-                    component_name="CardGroup",
-                ),
-                ApiDoc(
-                    component_metadata.get(
-                        "src/components/card/CardColumns.js"
-                    ),
-                    component_name="CardColumns",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/Card.js"),
-                    component_name="Card",
-                ),
-                ApiDoc(
-                    component_metadata.get(
-                        "src/components/card/CardHeader.js"
-                    ),
-                    component_name="CardHeader",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardBody.js"),
-                    component_name="CardBody",
-                ),
-                ApiDoc(
-                    component_metadata.get(
-                        "src/components/card/CardFooter.js"
-                    ),
-                    component_name="CardFooter",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardTitle.js"),
-                    component_name="CardTitle",
-                ),
-                ApiDoc(
-                    component_metadata.get(
-                        "src/components/card/CardSubtitle.js"
-                    ),
-                    component_name="CardSubtitle",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardLink.js"),
-                    component_name="CardLink",
-                ),
-                ApiDoc(
-                    component_metadata.get("src/components/card/CardImg.js"),
-                    component_name="CardImg",
-                ),
-                ApiDoc(
-                    component_metadata.get(
-                        "src/components/card/CardImgOverlay.js"
-                    ),
-                    component_name="CardImgOverlay",
-                ),
-            ],
+            "cards": cards_page,
             "collapse": [
                 ExampleContainer(
                     load_source_with_app(

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -2,11 +2,9 @@ from pathlib import Path
 
 import dash_bootstrap_components as dbc
 
-from .components.badges import badges
-from .components.buttons.group import buttons as buttons_group
-from .components.buttons.outline import buttons as buttons_outline
-from .components.buttons.simple import buttons as buttons_simple
 from .alerts_content import content as alerts_content
+from .buttons_content import get_content as get_buttons_content
+from .badges_content import content as badges_content
 from .cards_content import content as cards_content
 from .layout_content import content as layout_content
 
@@ -21,12 +19,7 @@ COMPONENTS = HERE / "components"
 
 GITHUB_LINK = "https://github.com/ASIDataScience/dash-bootstrap-components"
 
-badges_source = (COMPONENTS / "badges.py").open().read()
 collapse_source = (COMPONENTS / "collapse.py").open().read()
-buttons_simple_source = (COMPONENTS / "buttons" / "simple.py").open().read()
-buttons_usage_source = (COMPONENTS / "buttons" / "usage.py").open().read()
-buttons_outline_source = (COMPONENTS / "buttons" / "outline.py").open().read()
-buttons_group_source = (COMPONENTS / "buttons" / "group.py").open().read()
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -62,26 +55,8 @@ class ComponentsPage:
         self._app = app
         self._component_bodies = {
             "alerts": alerts_content,
-            "badges": [
-                ExampleContainer(badges),
-                HighlightedSource(badges_source),
-                ApiDoc(get_component_metadata("src/components/Badge.js")),
-            ],
-            "buttons": [
-                ExampleContainer(buttons_simple),
-                HighlightedSource(buttons_simple_source),
-                ExampleContainer(
-                    load_source_with_app(
-                        self._app, buttons_usage_source, "button"
-                    )
-                ),
-                HighlightedSource(buttons_usage_source),
-                ExampleContainer(buttons_outline),
-                HighlightedSource(buttons_outline_source),
-                ExampleContainer(buttons_group),
-                HighlightedSource(buttons_group_source),
-                ApiDoc(get_component_metadata("src/components/Button.js")),
-            ],
+            "badges": badges_content,
+            "buttons": get_buttons_content(self._app),
             "cards": cards_content,
             "collapse": [
                 ExampleContainer(

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -55,7 +55,7 @@ class ComponentsPage:
             "buttons": get_buttons_content(self._app),
             "cards": cards_content,
             "collapse": get_collapse_content(self._app),
-            "layout": layout_content
+            "layout": layout_content,
         }
 
     def for_path(self, path_components):

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -19,7 +19,7 @@ from .cards_page import page as cards_page
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
-from .metadata import load_metadata
+from .metadata import get_component_metadata
 from .sidebar import Sidebar, SidebarEntry
 
 
@@ -27,8 +27,6 @@ HERE = Path(__file__).parent
 COMPONENTS = HERE / "components"
 
 GITHUB_LINK = "https://github.com/ASIDataScience/dash-bootstrap-components"
-
-component_metadata = load_metadata()
 
 alerts_source = (COMPONENTS / "alerts.py").open().read()
 badges_source = (COMPONENTS / "badges.py").open().read()
@@ -89,12 +87,12 @@ class ComponentsPage:
             "alerts": [
                 ExampleContainer(alerts),
                 HighlightedSource(alerts_source),
-                ApiDoc(component_metadata.get("src/components/Alert.js")),
+                ApiDoc(get_component_metadata("src/components/Alert.js")),
             ],
             "badges": [
                 ExampleContainer(badges),
                 HighlightedSource(badges_source),
-                ApiDoc(component_metadata.get("src/components/Badge.js")),
+                ApiDoc(get_component_metadata("src/components/Badge.js")),
             ],
             "buttons": [
                 ExampleContainer(buttons_simple),
@@ -109,7 +107,7 @@ class ComponentsPage:
                 HighlightedSource(buttons_outline_source),
                 ExampleContainer(buttons_group),
                 HighlightedSource(buttons_group_source),
-                ApiDoc(component_metadata.get("src/components/Button.js")),
+                ApiDoc(get_component_metadata("src/components/Button.js")),
             ],
             "cards": cards_page,
             "collapse": [
@@ -119,7 +117,7 @@ class ComponentsPage:
                     )
                 ),
                 HighlightedSource(collapse_source),
-                ApiDoc(component_metadata.get("src/components/Collapse.js")),
+                ApiDoc(get_component_metadata("src/components/Collapse.js")),
             ],
             "layout": html.Div(
                 [
@@ -143,11 +141,11 @@ class ComponentsPage:
                     ExampleContainer(layout_horizontal),
                     HighlightedSource(layout_horizontal_source),
                     ApiDoc(
-                        component_metadata.get("src/components/layout/Row.js"),
+                        get_component_metadata("src/components/layout/Row.js"),
                         component_name="Row",
                     ),
                     ApiDoc(
-                        component_metadata.get("src/components/layout/Col.js"),
+                        get_component_metadata("src/components/layout/Col.js"),
                         component_name="Col",
                     ),
                 ],

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -3,14 +3,12 @@ from pathlib import Path
 import dash_bootstrap_components as dbc
 
 from .alerts_content import content as alerts_content
-from .buttons_content import get_content as get_buttons_content
 from .badges_content import content as badges_content
+from .buttons_content import get_content as get_buttons_content
 from .cards_content import content as cards_content
+from .collapse_content import get_content as get_collapse_content
 from .layout_content import content as layout_content
 
-from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
-from .api_doc import ApiDoc
-from .metadata import get_component_metadata
 from .sidebar import Sidebar, SidebarEntry
 
 
@@ -18,8 +16,6 @@ HERE = Path(__file__).parent
 COMPONENTS = HERE / "components"
 
 GITHUB_LINK = "https://github.com/ASIDataScience/dash-bootstrap-components"
-
-collapse_source = (COMPONENTS / "collapse.py").open().read()
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -58,15 +54,7 @@ class ComponentsPage:
             "badges": badges_content,
             "buttons": get_buttons_content(self._app),
             "cards": cards_content,
-            "collapse": [
-                ExampleContainer(
-                    load_source_with_app(
-                        self._app, collapse_source, "collapse"
-                    )
-                ),
-                HighlightedSource(collapse_source),
-                ApiDoc(get_component_metadata("src/components/Collapse.js")),
-            ],
+            "collapse": get_collapse_content(self._app),
             "layout": layout_content
         }
 

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -8,14 +8,8 @@ from .components.badges import badges
 from .components.buttons.group import buttons as buttons_group
 from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.simple import buttons as buttons_simple
-from .components.layout.breakpoints import row as layout_breakpoints
-from .components.layout.horizontal import row as layout_horizontal
-from .components.layout.no_gutters import row as layout_no_gutters
-from .components.layout.order_offset import row as layout_order_offset
-from .components.layout.simple import row as layout_simple
-from .components.layout.vertical import row as layout_vertical
-from .components.layout.width import row as layout_width
 from .cards_content import content as cards_content
+from .layout_content import content as layout_content
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -35,21 +29,6 @@ buttons_simple_source = (COMPONENTS / "buttons" / "simple.py").open().read()
 buttons_usage_source = (COMPONENTS / "buttons" / "usage.py").open().read()
 buttons_outline_source = (COMPONENTS / "buttons" / "outline.py").open().read()
 buttons_group_source = (COMPONENTS / "buttons" / "group.py").open().read()
-layout_simple_source = (COMPONENTS / "layout" / "simple.py").open().read()
-layout_width_source = (COMPONENTS / "layout" / "width.py").open().read()
-layout_order_offset_source = (
-    (COMPONENTS / "layout" / "order_offset.py").open().read()
-)
-layout_breakpoints_source = (
-    (COMPONENTS / "layout" / "breakpoints.py").open().read()
-)
-layout_no_gutters_source = (
-    (COMPONENTS / "layout" / "no_gutters.py").open().read()
-)
-layout_vertical_source = (COMPONENTS / "layout" / "vertical.py").open().read()
-layout_horizontal_source = (
-    (COMPONENTS / "layout" / "horizontal.py").open().read()
-)
 
 NAVBAR = dbc.Navbar(
     brand="Dash Bootstrap Components",
@@ -119,38 +98,7 @@ class ComponentsPage:
                 HighlightedSource(collapse_source),
                 ApiDoc(get_component_metadata("src/components/Collapse.js")),
             ],
-            "layout": html.Div(
-                [
-                    ExampleContainer(layout_simple),
-                    HighlightedSource(layout_simple_source),
-                    ExampleContainer(layout_width),
-                    HighlightedSource(layout_width_source),
-                    ExampleContainer(layout_order_offset),
-                    HighlightedSource(layout_order_offset_source),
-                    ExampleContainer(layout_breakpoints),
-                    HighlightedSource(layout_breakpoints_source),
-                    ExampleContainer(layout_no_gutters),
-                    HighlightedSource(layout_no_gutters_source),
-                    html.Div(
-                        [
-                            ExampleContainer(layout_vertical),
-                            HighlightedSource(layout_vertical_source),
-                        ],
-                        className="pad-row",
-                    ),
-                    ExampleContainer(layout_horizontal),
-                    HighlightedSource(layout_horizontal_source),
-                    ApiDoc(
-                        get_component_metadata("src/components/layout/Row.js"),
-                        component_name="Row",
-                    ),
-                    ApiDoc(
-                        get_component_metadata("src/components/layout/Col.js"),
-                        component_name="Col",
-                    ),
-                ],
-                className="layout-demo",
-            ),
+            "layout": layout_content
         }
 
     def for_path(self, path_components):

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 
 import dash_bootstrap_components as dbc
-import dash_html_components as html
 
-from .components.alerts import alerts
 from .components.badges import badges
 from .components.buttons.group import buttons as buttons_group
 from .components.buttons.outline import buttons as buttons_outline
 from .components.buttons.simple import buttons as buttons_simple
+from .alerts_content import content as alerts_content
 from .cards_content import content as cards_content
 from .layout_content import content as layout_content
 
@@ -22,7 +21,6 @@ COMPONENTS = HERE / "components"
 
 GITHUB_LINK = "https://github.com/ASIDataScience/dash-bootstrap-components"
 
-alerts_source = (COMPONENTS / "alerts.py").open().read()
 badges_source = (COMPONENTS / "badges.py").open().read()
 collapse_source = (COMPONENTS / "collapse.py").open().read()
 buttons_simple_source = (COMPONENTS / "buttons" / "simple.py").open().read()
@@ -63,11 +61,7 @@ class ComponentsPage:
     def __init__(self, app):
         self._app = app
         self._component_bodies = {
-            "alerts": [
-                ExampleContainer(alerts),
-                HighlightedSource(alerts_source),
-                ApiDoc(get_component_metadata("src/components/Alert.js")),
-            ],
+            "alerts": alerts_content,
             "badges": [
                 ExampleContainer(badges),
                 HighlightedSource(badges_source),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -15,7 +15,7 @@ from .components.layout.order_offset import row as layout_order_offset
 from .components.layout.simple import row as layout_simple
 from .components.layout.vertical import row as layout_vertical
 from .components.layout.width import row as layout_width
-from .cards_page import page as cards_page
+from .cards_content import content as cards_content
 
 from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
@@ -109,7 +109,7 @@ class ComponentsPage:
                 HighlightedSource(buttons_group_source),
                 ApiDoc(get_component_metadata("src/components/Button.js")),
             ],
-            "cards": cards_page,
+            "cards": cards_content,
             "collapse": [
                 ExampleContainer(
                     load_source_with_app(


### PR DESCRIPTION
As discussed in PRs #35 and #29 , the current structure where we define the entire components page in a single source file, `components_page/page.py`, gets unwieldy. This PR refactors the structure of that page so it just loads a page for each component, `components_page/<component>_content.py`.

This leads to a much more extensible structure overall. It makes it more natural to add additional documentation sections for individual components.

There is no visible change to the documentation. I have verified that the documentation still works as before.