### PR TITLE
Rename Fade in prop

### DIFF
--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -94,7 +94,7 @@ class FadeComponent extends Component {
       <Button onClick={this.toggle} style={{
           marginBottom: "1rem"
         }}>Toggle fade</Button>
-      <Fade in={this.state.fadeIn}>
+      <Fade is_in={this.state.fadeIn}>
         {this.props.children}
       </Fade>
     </div>)

--- a/examples/app.py
+++ b/examples/app.py
@@ -264,6 +264,7 @@ fade = html.Div(
                 dbc.CardBody(dbc.CardText("This content fades in and out"))
             ),
             id="fade",
+            is_in=True,
         ),
     ]
 )
@@ -476,9 +477,9 @@ def toggle_collapse(n, is_open):
 
 
 @app.callback(
-    Output("fade", "in"),
+    Output("fade", "is_in"),
     [Input("fade-button", "n_clicks")],
-    [State("fade", "in")],
+    [State("fade", "is_in")],
 )
 def toggle_fade(n, is_in):
     if n:

--- a/src/components/Fade.js
+++ b/src/components/Fade.js
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import {Fade as RSFade} from 'reactstrap';
 
 const Fade = props => {
-  const {children, base_class, base_class_active, ...otherProps} = props;
+  const {children, base_class, base_class_active, is_in, ...otherProps} = props;
   return (
     <RSFade
       baseClass={base_class}
       baseClassActive={base_class_active}
+      in={is_in}
       {...otherProps}
     >
       {children}
@@ -36,7 +37,12 @@ Fade.propTypes = {
    * Often used with CSS to style elements with common properties.
    */
   className: PropTypes.string,
-  in: PropTypes.bool,
+
+  /**
+   * Controls whether the children of the Fade component are currently visible
+   * or not.
+   */
+  is_in: PropTypes.bool,
 
   /**
    * The duration of the transition, in milliseconds.


### PR DESCRIPTION
This PR renames the `in` prop of the `Fade` component to `is_in`. This allows the initial value to be specified in the python interface (previously a syntax error was thrown because `in` is of course a reserved word in Python), and also more closely shadows the `is_open` prop of `Collapse`.