### PR TITLE
Docs title undo redo

### DIFF
--- a/docs/app.py
+++ b/docs/app.py
@@ -51,6 +51,7 @@ class App:
             # bound onto the page.
             suppress_callback_exceptions=True,
         )
+        app.title = "Dash Bootstrap Components"
         return cls(app)
 
     def _create_layout(self):

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -117,3 +117,7 @@ span.hljs-meta {
   background-color: rgba(86, 61, 124, .15);
   border: 1px solid rgba(86, 61, 124, .2);
 }
+
+._dash-undo-redo {
+  display: none;
+}

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.13.1/build/styles/monokai-sublime.min.css">
     <link rel="stylesheet" href="/assets/docs.css" />
+    <title>Dash Bootstrap Components</title>
   </head>
   <body>
     <div class="jumbotron text-center mb-3 main-header">

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
-exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py
+exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py, docs/components_page/components/popover.py
 ignore = E203, W503
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
This small PR hides the Dash undo redo buttons from the documentation app, and changes the title to "Dash Bootstrap Components"