### PR TITLE
Add bootstrap compatible date pickers

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -18,12 +18,7 @@ _js_dist = [
     }
 ]
 
-_css_dist = [
-    {
-        "relative_package_path": "react-dates-shim.css",
-        "namespace": "dash_bootstrap_components",
-    }
-]
+_css_dist = []
 
 
 def _setup_js_components(module, path_to_metadata):

--- a/dash_bootstrap_components/react-dates-shim.css
+++ b/dash_bootstrap_components/react-dates-shim.css
@@ -1,3 +1,0 @@
-.form-group > .SingleDatePicker, .form-group > .DateRangePicker {
-  display: table;
-}

--- a/examples/date_picker.py
+++ b/examples/date_picker.py
@@ -38,8 +38,80 @@ app.layout = dbc.Container(
             initial_visible_month=datetime(2018, 1, 1), bs_size="lg"
         ),
         html.Br(),
-        html.H3("Date Core Components"),
+        html.H3("Dash Core Components"),
         dcc.DatePickerRange(initial_visible_month=datetime(2018, 1, 1)),
+        html.Br(),
+        html.H3("FormGroup"),
+        dbc.Row(
+            [
+                dbc.Col(
+                    dbc.FormGroup(
+                        [
+                            dbc.Label("Type a thing"),
+                            dbc.Input(type="text", bs_size="sm"),
+                        ]
+                    )
+                ),
+                dbc.Col(
+                    dbc.FormGroup(
+                        [
+                            dbc.Label("Choose a date"),
+                            dbc.DatePickerSingle(
+                                initial_visible_month=datetime(2018, 1, 1),
+                                bs_size="sm",
+                            ),
+                        ]
+                    ),
+                    width="auto",
+                ),
+            ]
+        ),
+        html.Br(),
+        dbc.Row(
+            [
+                dbc.Col(
+                    dbc.FormGroup(
+                        [dbc.Label("Type a thing"), dbc.Input(type="text")]
+                    )
+                ),
+                dbc.Col(
+                    dbc.FormGroup(
+                        [
+                            dbc.Label("Choose a date"),
+                            dbc.DatePickerSingle(
+                                initial_visible_month=datetime(2018, 1, 1)
+                            ),
+                        ]
+                    ),
+                    width="auto",
+                ),
+            ]
+        ),
+        html.Br(),
+        dbc.Row(
+            [
+                dbc.Col(
+                    dbc.FormGroup(
+                        [
+                            dbc.Label("Type a thing"),
+                            dbc.Input(type="text", bs_size="lg"),
+                        ]
+                    )
+                ),
+                dbc.Col(
+                    dbc.FormGroup(
+                        [
+                            dbc.Label("Choose a date"),
+                            dbc.DatePickerSingle(
+                                initial_visible_month=datetime(2018, 1, 1),
+                                bs_size="lg",
+                            ),
+                        ]
+                    ),
+                    width="auto",
+                ),
+            ]
+        ),
     ]
 )
 

--- a/examples/date_picker.py
+++ b/examples/date_picker.py
@@ -2,11 +2,21 @@ from datetime import datetime
 
 import dash
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 
 app = dash.Dash()
 
 app.layout = dbc.Container(
-    dbc.DatePickerSingle(initial_visible_month=datetime(2018, 1, 1))
+    [
+        html.H1("Date picker testing"),
+        dbc.DatePickerSingle(initial_visible_month=datetime(2018, 1, 1)),
+        dbc.DatePickerSingle(
+            initial_visible_month=datetime(2018, 1, 1), bs_size="sm"
+        ),
+        dbc.DatePickerSingle(
+            initial_visible_month=datetime(2018, 1, 1), bs_size="lg"
+        ),
+    ]
 )
 
 

--- a/examples/date_picker.py
+++ b/examples/date_picker.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+import dash
+import dash_bootstrap_components as dbc
+
+app = dash.Dash()
+
+app.layout = dbc.Container(
+    dbc.DatePickerSingle(initial_visible_month=datetime(2018, 1, 1))
+)
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888, debug=True)

--- a/examples/date_picker.py
+++ b/examples/date_picker.py
@@ -1,9 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_html_components as html
+
+SUNDAYS = [datetime(2018, 11, 4) + timedelta(7 * i) for i in range(4)]
 
 app = dash.Dash()
 
@@ -36,6 +38,21 @@ app.layout = dbc.Container(
         html.H6("Large"),
         dbc.DatePickerRange(
             initial_visible_month=datetime(2018, 1, 1), bs_size="lg"
+        ),
+        html.Br(),
+        html.H3("Disabled days"),
+        dbc.DatePickerSingle(
+            initial_visible_month=datetime(2018, 11, 8),
+            min_date_allowed=datetime(2018, 11, 1),
+            max_date_allowed=datetime(2018, 11, 30),
+            disabled_days=SUNDAYS,
+        ),
+        html.Br(),
+        dbc.DatePickerRange(
+            initial_visible_month=datetime(2018, 11, 8),
+            min_date_allowed=datetime(2018, 11, 1),
+            max_date_allowed=datetime(2018, 11, 30),
+            disabled_days=SUNDAYS,
         ),
         html.Br(),
         html.H3("Dash Core Components"),

--- a/examples/date_picker.py
+++ b/examples/date_picker.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import dash
 import dash_bootstrap_components as dbc
+import dash_core_components as dcc
 import dash_html_components as html
 
 app = dash.Dash()
@@ -9,13 +10,36 @@ app = dash.Dash()
 app.layout = dbc.Container(
     [
         html.H1("Date picker testing"),
+        html.H3("DatePickerSingle"),
+        html.H6("Medium"),
         dbc.DatePickerSingle(initial_visible_month=datetime(2018, 1, 1)),
+        html.Br(),
+        html.H6("Small"),
         dbc.DatePickerSingle(
             initial_visible_month=datetime(2018, 1, 1), bs_size="sm"
         ),
+        html.Br(),
+        html.H6("Large"),
         dbc.DatePickerSingle(
             initial_visible_month=datetime(2018, 1, 1), bs_size="lg"
         ),
+        html.Br(),
+        html.H3("DatePickerRange"),
+        html.H6("Medium"),
+        dbc.DatePickerRange(initial_visible_month=datetime(2018, 1, 1)),
+        html.Br(),
+        html.H6("Small"),
+        dbc.DatePickerRange(
+            initial_visible_month=datetime(2018, 1, 1), bs_size="sm"
+        ),
+        html.Br(),
+        html.H6("Large"),
+        dbc.DatePickerRange(
+            initial_visible_month=datetime(2018, 1, 1), bs_size="lg"
+        ),
+        html.Br(),
+        html.H3("Date Core Components"),
+        dcc.DatePickerRange(initial_visible_month=datetime(2018, 1, 1)),
     ]
 )
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,12 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "is-absolute-url": "^2.1.0",
+    "moment": "^2.22.2",
     "prop-types": "^15.6.2",
     "ramda": "^0.25.0",
     "react": "^16.5.2",
+    "react-addons-shallow-compare": "^15.6.0",
+    "react-dates": "^12.3.0",
     "react-dom": "^16.5.2",
     "reactstrap": "^6.4.0"
   },

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -1,0 +1,356 @@
+import {DateRangePicker} from 'react-dates';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import * as R from 'ramda';
+import React, {Component} from 'react';
+
+/**
+ * DatePickerRange is a tailor made component designed for selecting
+ * timespan across multiple days off of a calendar.
+ *
+ * The DatePicker integrates well with the Python datetime module with the
+ * startDate and endDate being returned in a string format suitable for
+ * creating datetime objects.
+ *
+ * This component is based off of Airbnb's react-dates react component
+ * which can be found here: https://github.com/airbnb/react-dates
+ */
+export default class DatePickerRange extends Component {
+  constructor() {
+    super();
+    this.propsToState = this.propsToState.bind(this);
+    this.onDatesChange = this.onDatesChange.bind(this);
+    this.isOutsideRange = this.isOutsideRange.bind(this);
+  }
+
+  propsToState(newProps) {
+    /*
+         * state includes:
+         * - user modifiable attributes
+         * - moment converted attributes
+         */
+    const newState = {};
+    const momentProps = [
+      'start_date',
+      'end_date',
+      'initial_visible_month',
+      'max_date_allowed',
+      'min_date_allowed'
+    ];
+    momentProps.forEach(prop => {
+      if (R.type(newProps[prop]) !== 'Undefined') {
+        newState[prop] = moment(newProps[prop]);
+      }
+      if (prop === 'max_date_allowed' && R.has(prop, newState)) {
+        newState[prop].add(1, 'days');
+      }
+    });
+    this.setState(newState);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.propsToState(newProps);
+  }
+
+  componentWillMount() {
+    this.propsToState(this.props);
+  }
+  onDatesChange({startDate: start_date, endDate: end_date}) {
+    const {setProps, fireEvent, updatemode} = this.props;
+    const old_start_date = this.state.start_date;
+    const old_end_date = this.state.end_date;
+    const newState = {};
+    if (setProps && start_date !== null && start_date !== old_start_date) {
+      if (updatemode === 'singledate') {
+        setProps({start_date: start_date.format('YYYY-MM-DD')});
+      }
+    }
+
+    newState.start_date = start_date;
+
+    if (setProps && end_date !== null && end_date !== old_end_date) {
+      if (updatemode === 'singledate') {
+        setProps({end_date: end_date.format('YYYY-MM-DD')});
+      } else if (updatemode === 'bothdates') {
+        setProps({
+          start_date: start_date.format('YYYY-MM-DD'),
+          end_date: end_date.format('YYYY-MM-DD')
+        });
+      }
+    }
+    newState.end_date = end_date;
+
+    if (fireEvent) {
+      fireEvent('change');
+    }
+
+    this.setState(newState);
+  }
+
+  isOutsideRange(date) {
+    const {min_date_allowed, max_date_allowed} = this.state;
+    const notUndefined = R.complement(
+      R.pipe(
+        R.type,
+        R.equals('Undefined')
+      )
+    );
+    return (
+      (notUndefined(min_date_allowed) && date < min_date_allowed) ||
+      (notUndefined(max_date_allowed) && date >= max_date_allowed)
+    );
+  }
+
+  render() {
+    const {
+      start_date,
+      end_date,
+      focusedInput,
+      initial_visible_month
+    } = this.state;
+
+    const {
+      calendar_orientation,
+      clearable,
+      day_size,
+      disabled,
+      display_format,
+      end_date_placeholder_text,
+      first_day_of_week,
+      is_RTL,
+      minimum_nights,
+      month_format,
+      number_of_months_shown,
+      reopen_calendar_on_clear,
+      show_outside_days,
+      start_date_placeholder_text,
+      stay_open_on_select,
+      with_full_screen_portal,
+      with_portal
+    } = this.props;
+
+    const verticalFlag = calendar_orientation !== 'vertical';
+
+    return (
+      <DateRangePicker
+        daySize={day_size}
+        disabled={disabled}
+        displayFormat={display_format}
+        enableOutsideDays={show_outside_days}
+        endDate={end_date}
+        endDatePlaceholderText={end_date_placeholder_text}
+        firstDayOfWeek={first_day_of_week}
+        focusedInput={focusedInput}
+        initialVisibleMonth={() => {
+          if (initial_visible_month) {
+            return initial_visible_month;
+          }
+          if (focusedInput === 'endDate') {
+            return end_date;
+          }
+          return start_date;
+        }}
+        isOutsideRange={this.isOutsideRange}
+        isRTL={is_RTL}
+        keepOpenOnDateSelect={stay_open_on_select}
+        minimumNights={minimum_nights}
+        monthFormat={month_format}
+        numberOfMonths={number_of_months_shown}
+        onDatesChange={this.onDatesChange}
+        onFocusChange={focusedInput => this.setState({focusedInput})}
+        orientation={calendar_orientation}
+        reopenPickerOnClearDates={reopen_calendar_on_clear}
+        showClearDates={clearable}
+        startDate={start_date}
+        startDatePlaceholderText={start_date_placeholder_text}
+        withFullScreenPortal={with_full_screen_portal && verticalFlag}
+        withPortal={with_portal && verticalFlag}
+      />
+    );
+  }
+}
+
+DatePickerRange.propTypes = {
+  id: PropTypes.string,
+
+  /**
+   * Specifies the starting date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  start_date: PropTypes.string,
+
+  /**
+   * Specifies the ending date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  end_date: PropTypes.string,
+
+  /**
+   * Specifies the lowest selectable date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  min_date_allowed: PropTypes.string,
+
+  /**
+   * Specifies the highest selectable date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  max_date_allowed: PropTypes.string,
+
+  /**
+   * Specifies the month that is initially presented when the user
+   * opens the calendar. Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   *
+   */
+  initial_visible_month: PropTypes.string,
+
+  /**
+   * Text that will be displayed in the first input
+   * box of the date picker when no date is selected. Default value is 'Start Date'
+   */
+  start_date_placeholder_text: PropTypes.string,
+
+  /**
+   * Text that will be displayed in the second input
+   * box of the date picker when no date is selected. Default value is 'End Date'
+   */
+  end_date_placeholder_text: PropTypes.string,
+
+  /**
+   * Size of rendered calendar days, higher number
+   * means bigger day size and larger calendar overall
+   */
+  day_size: PropTypes.number,
+
+  /**
+   * Orientation of calendar, either vertical or horizontal.
+   * Valid options are 'vertical' or 'horizontal'.
+   */
+  calendar_orientation: PropTypes.oneOf(['vertical', 'horizontal']),
+
+  /**
+   * Determines whether the calendar and days operate
+   * from left to right or from right to left
+   */
+  is_RTL: PropTypes.bool,
+
+  /**
+   * If True, the calendar will automatically open when cleared
+   */
+  reopen_calendar_on_clear: PropTypes.bool,
+
+  /**
+   * Number of calendar months that are shown when calendar is opened
+   */
+  number_of_months_shown: PropTypes.number,
+
+  /**
+   * If True, calendar will open in a screen overlay portal,
+   * not supported on vertical calendar
+   */
+  with_portal: PropTypes.bool,
+
+  /**
+   * If True, calendar will open in a full screen overlay portal, will
+   * take precedent over 'withPortal' if both are set to true,
+   * not supported on vertical calendar
+   */
+  with_full_screen_portal: PropTypes.bool,
+
+  /**
+   * Specifies what day is the first day of the week, values must be
+   * from [0, ..., 6] with 0 denoting Sunday and 6 denoting Saturday
+   */
+  first_day_of_week: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+
+  /**
+   * Specifies a minimum number of nights that must be selected between
+   * the startDate and the endDate
+   */
+  minimum_nights: PropTypes.number,
+
+  /**
+   * If True the calendar will not close when the user has selected a value
+   * and will wait until the user clicks off the calendar
+   */
+  stay_open_on_select: PropTypes.bool,
+
+  /**
+   * If True the calendar will display days that rollover into
+   * the next month
+   */
+  show_outside_days: PropTypes.bool,
+
+  /**
+   * Specifies the format that the month will be displayed in the calendar,
+   * valid formats are variations of "MM YY". For example:
+   * "MM YY" renders as '05 97' for May 1997
+   * "MMMM, YYYY" renders as 'May, 1997' for May 1997
+   * "MMM, YY" renders as 'Sep, 97' for September 1997
+   */
+  month_format: PropTypes.string,
+
+  /**
+   * Specifies the format that the selected dates will be displayed
+   * valid formats are variations of "MM YY DD". For example:
+   * "MM YY DD" renders as '05 10 97' for May 10th 1997
+   * "MMMM, YY" renders as 'May, 1997' for May 10th 1997
+   * "M, D, YYYY" renders as '07, 10, 1997' for September 10th 1997
+   * "MMMM" renders as 'May' for May 10 1997
+   */
+  display_format: PropTypes.string,
+
+  /**
+   * If True, no dates can be selected.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Whether or not the dropdown is "clearable", that is, whether or
+   * not a small "x" appears on the right of the dropdown that removes
+   * the selected value.
+   */
+  clearable: PropTypes.bool,
+
+  /**
+   * Dash-assigned callback that gets fired when the value changes.
+   */
+  setProps: PropTypes.func,
+
+  /**
+   * Dash-assigned callback that gets fired when the value changes.
+   */
+  dashEvents: PropTypes.oneOf(['change']),
+
+  /**
+   * Determines when the component should update
+   * its value. If `bothdates`, then the DatePicker
+   * will only trigger its value when the user has
+   * finished picking both dates. If `singledate`, then
+   * the DatePicker will update its value
+   * as one date is picked.
+   */
+  updatemode: PropTypes.oneOf(['singledate', 'bothdates']),
+
+  fireEvent: PropTypes.func
+};
+
+DatePickerRange.defaultProps = {
+  calendar_orientation: 'horizontal',
+  is_RTL: false,
+  day_size: 39,
+  with_portal: false,
+  with_full_screen_portal: false,
+  first_day_of_week: 0,
+  number_of_months_shown: 1,
+  stay_open_on_select: false,
+  reopen_calendar_on_clear: false,
+  clearable: false,
+  disabled: false,
+  updatemode: 'singledate'
+};

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -52,6 +52,10 @@ export default class DatePickerRange extends Component {
         newState[prop].add(1, 'days');
       }
     });
+    const disabled_days = newProps['disabled_days'];
+    if (R.type(disabled_days) != 'Undefined') {
+      newState['disabled_days'] = disabled_days.map(d => moment(d));
+    }
     this.setState(newState);
   }
 
@@ -95,7 +99,7 @@ export default class DatePickerRange extends Component {
   }
 
   isOutsideRange(date) {
-    const {min_date_allowed, max_date_allowed} = this.state;
+    const {min_date_allowed, max_date_allowed, disabled_days} = this.state;
     const notUndefined = R.complement(
       R.pipe(
         R.type,
@@ -104,7 +108,8 @@ export default class DatePickerRange extends Component {
     );
     return (
       (notUndefined(min_date_allowed) && date < min_date_allowed) ||
-      (notUndefined(max_date_allowed) && date >= max_date_allowed)
+      (notUndefined(max_date_allowed) && date >= max_date_allowed) ||
+      (notUndefined(disabled_days) && disabled_days.some(d => d.isSame(date, 'day')))
     );
   }
 
@@ -348,6 +353,12 @@ DatePickerRange.propTypes = {
    * as one date is picked.
    */
   updatemode: PropTypes.oneOf(['singledate', 'bothdates']),
+
+  /**
+   * A list of days to disable in addition to any that fall outside of the range
+   * specified by min_date_allowed and max_date_allowed.
+   */
+  disabled_days: PropTypes.arrayOf(PropTypes.string),
 
   /**
    * Set the size of the DatePickerSingle

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -3,6 +3,13 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
 import React, {Component} from 'react';
+import classNames from 'classnames';
+import './react-dates@12.3.0.css';
+
+const sizeMap = {
+  sm: 'dbc-datepicker-sm',
+  lg: 'dbc-datepicker-lg'
+};
 
 /**
  * DatePickerRange is a tailor made component designed for selecting
@@ -126,46 +133,51 @@ export default class DatePickerRange extends Component {
       start_date_placeholder_text,
       stay_open_on_select,
       with_full_screen_portal,
-      with_portal
+      with_portal,
+      bs_size
     } = this.props;
+
+    const sizeClass = classNames('dbc-datepicker', sizeMap[bs_size]);
 
     const verticalFlag = calendar_orientation !== 'vertical';
 
     return (
-      <DateRangePicker
-        daySize={day_size}
-        disabled={disabled}
-        displayFormat={display_format}
-        enableOutsideDays={show_outside_days}
-        endDate={end_date}
-        endDatePlaceholderText={end_date_placeholder_text}
-        firstDayOfWeek={first_day_of_week}
-        focusedInput={focusedInput}
-        initialVisibleMonth={() => {
-          if (initial_visible_month) {
-            return initial_visible_month;
-          }
-          if (focusedInput === 'endDate') {
-            return end_date;
-          }
-          return start_date;
-        }}
-        isOutsideRange={this.isOutsideRange}
-        isRTL={is_RTL}
-        keepOpenOnDateSelect={stay_open_on_select}
-        minimumNights={minimum_nights}
-        monthFormat={month_format}
-        numberOfMonths={number_of_months_shown}
-        onDatesChange={this.onDatesChange}
-        onFocusChange={focusedInput => this.setState({focusedInput})}
-        orientation={calendar_orientation}
-        reopenPickerOnClearDates={reopen_calendar_on_clear}
-        showClearDates={clearable}
-        startDate={start_date}
-        startDatePlaceholderText={start_date_placeholder_text}
-        withFullScreenPortal={with_full_screen_portal && verticalFlag}
-        withPortal={with_portal && verticalFlag}
-      />
+      <div className={sizeClass}>
+        <DateRangePicker
+          daySize={day_size}
+          disabled={disabled}
+          displayFormat={display_format}
+          enableOutsideDays={show_outside_days}
+          endDate={end_date}
+          endDatePlaceholderText={end_date_placeholder_text}
+          firstDayOfWeek={first_day_of_week}
+          focusedInput={focusedInput}
+          initialVisibleMonth={() => {
+            if (initial_visible_month) {
+              return initial_visible_month;
+            }
+            if (focusedInput === 'endDate') {
+              return end_date;
+            }
+            return start_date;
+          }}
+          isOutsideRange={this.isOutsideRange}
+          isRTL={is_RTL}
+          keepOpenOnDateSelect={stay_open_on_select}
+          minimumNights={minimum_nights}
+          monthFormat={month_format}
+          numberOfMonths={number_of_months_shown}
+          onDatesChange={this.onDatesChange}
+          onFocusChange={focusedInput => this.setState({focusedInput})}
+          orientation={calendar_orientation}
+          reopenPickerOnClearDates={reopen_calendar_on_clear}
+          showClearDates={clearable}
+          startDate={start_date}
+          startDatePlaceholderText={start_date_placeholder_text}
+          withFullScreenPortal={with_full_screen_portal && verticalFlag}
+          withPortal={with_portal && verticalFlag}
+        />
+      </div>
     );
   }
 }
@@ -336,6 +348,11 @@ DatePickerRange.propTypes = {
    * as one date is picked.
    */
   updatemode: PropTypes.oneOf(['singledate', 'bothdates']),
+
+  /**
+   * Set the size of the DatePickerSingle
+   */
+  bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
 
   fireEvent: PropTypes.func
 };

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -3,11 +3,12 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
 import React, {Component} from 'react';
+import classNames from 'classnames';
 import './react-dates@12.3.0.css';
 
 const sizeMap = {
-  sm: 'date-picker-sm',
-  lg: 'date-picker-lg'
+  sm: 'dbc-datepicker-sm',
+  lg: 'dbc-datepicker-lg'
 };
 
 /**
@@ -111,7 +112,7 @@ export default class DatePickerSingle extends Component {
       bs_size
     } = this.props;
 
-    const sizeClass = sizeMap[bs_size];
+    const sizeClass = classNames('dbc-datepicker', sizeMap[bs_size]);
 
     const verticalFlag = calendar_orientation !== 'vertical';
 

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -1,0 +1,291 @@
+import {SingleDatePicker} from 'react-dates';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import * as R from 'ramda';
+import React, {Component} from 'react';
+import './react-dates@12.3.0.css'
+
+/**
+ * DatePickerSingle is a tailor made component designed for selecting
+ * a single day off of a calendar.
+ *
+ * The DatePicker integrates well with the Python datetime module with the
+ * startDate and endDate being returned in a string format suitable for
+ * creating datetime objects.
+ *
+ * This component is based off of Airbnb's react-dates react component
+ * which can be found here: https://github.com/airbnb/react-dates
+ */
+export default class DatePickerSingle extends Component {
+  constructor() {
+    super();
+    this.propsToState = this.propsToState.bind(this);
+    this.isOutsideRange = this.isOutsideRange.bind(this);
+    this.onDateChange = this.onDateChange.bind(this);
+  }
+
+  propsToState(newProps) {
+    console.log(R);
+    /*
+         * state includes:
+         * - user modifiable attributes
+         * - moment converted attributes
+         */
+    const newState = {};
+    const momentProps = [
+      'date',
+      'initial_visible_month',
+      'max_date_allowed',
+      'min_date_allowed'
+    ];
+    momentProps.forEach(prop => {
+      if (R.type(newProps[prop]) !== 'Undefined') {
+        newState[prop] = moment(newProps[prop]);
+      }
+      if (prop === 'max_date_allowed' && R.has(prop, newState)) {
+        newState[prop].add(1, 'days');
+      }
+    });
+    this.setState(newState);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.propsToState(newProps);
+  }
+
+  componentWillMount() {
+    this.propsToState(this.props);
+  }
+
+  isOutsideRange(date) {
+    const {min_date_allowed, max_date_allowed} = this.state;
+
+    const notUndefined = R.complement(
+      R.pipe(
+        R.type,
+        R.equals('Undefined')
+      )
+    );
+    return (
+      (notUndefined(min_date_allowed) && date < min_date_allowed) ||
+      (notUndefined(max_date_allowed) && date >= max_date_allowed)
+    );
+  }
+
+  onDateChange(date) {
+    const {setProps, fireEvent} = this.props;
+    if (setProps && date !== null) {
+      setProps({date: date.format('YYYY-MM-DD')});
+    } else {
+      this.setState({date});
+    }
+    if (fireEvent) {
+      fireEvent('change');
+    }
+  }
+
+  render() {
+    const {date, focused, initial_visible_month} = this.state;
+
+    const {
+      calendar_orientation,
+      clearable,
+      day_size,
+      disabled,
+      display_format,
+      first_day_of_week,
+      is_RTL,
+      month_format,
+      number_of_months_shown,
+      placeholder,
+      reopen_calendar_on_clear,
+      show_outside_days,
+      stay_open_on_select,
+      with_full_screen_portal,
+      with_portal
+    } = this.props;
+
+    const verticalFlag = calendar_orientation !== 'vertical';
+
+    return (
+      <SingleDatePicker
+        date={date}
+        onDateChange={this.onDateChange}
+        focused={focused}
+        onFocusChange={({focused}) => this.setState({focused})}
+        initialVisibleMonth={() => date || initial_visible_month}
+        isOutsideRange={this.isOutsideRange}
+        numberOfMonths={number_of_months_shown}
+        withPortal={with_portal && verticalFlag}
+        withFullScreenPortal={with_full_screen_portal && verticalFlag}
+        firstDayOfWeek={first_day_of_week}
+        enableOutsideDays={show_outside_days}
+        monthFormat={month_format}
+        displayFormat={display_format}
+        placeholder={placeholder}
+        showClearDate={clearable}
+        disabled={disabled}
+        keepOpenOnDateSelect={stay_open_on_select}
+        reopenPickerOnClearDate={reopen_calendar_on_clear}
+        isRTL={is_RTL}
+        orientation={calendar_orientation}
+        daySize={day_size}
+      />
+    );
+  }
+}
+
+DatePickerSingle.propTypes = {
+  id: PropTypes.string,
+
+  /**
+   * Specifies the starting date for the component, best practice is to pass
+   * value via datetime object
+   */
+  date: PropTypes.string,
+
+  /**
+   * Specifies the lowest selectable date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  min_date_allowed: PropTypes.string,
+
+  /**
+   * Specifies the highest selectable date for the component.
+   * Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   */
+  max_date_allowed: PropTypes.string,
+
+  /**
+   * Specifies the month that is initially presented when the user
+   * opens the calendar. Accepts datetime.datetime objects or strings
+   * in the format 'YYYY-MM-DD'
+   *
+   */
+  initial_visible_month: PropTypes.string,
+
+  /**
+   * Size of rendered calendar days, higher number
+   * means bigger day size and larger calendar overall
+   */
+  day_size: PropTypes.number,
+
+  /**
+   * Orientation of calendar, either vertical or horizontal.
+   * Valid options are 'vertical' or 'horizontal'.
+   */
+  calendar_orientation: PropTypes.oneOf(['vertical', 'horizontal']),
+
+  /**
+   * Determines whether the calendar and days operate
+   * from left to right or from right to left
+   */
+  is_RTL: PropTypes.bool,
+  /**
+   * Text that will be displayed in the input
+   * box of the date picker when no date is selected.
+   * Default value is 'Start Date'
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * If True, the calendar will automatically open when cleared
+   */
+  reopen_calendar_on_clear: PropTypes.bool,
+
+  /**
+   * Number of calendar months that are shown when calendar is opened
+   */
+  number_of_months_shown: PropTypes.number,
+
+  /**
+   * If True, calendar will open in a screen overlay portal,
+   * not supported on vertical calendar
+   */
+  with_portal: PropTypes.bool,
+
+  /**
+   * If True, calendar will open in a full screen overlay portal, will
+   * take precedent over 'withPortal' if both are set to True,
+   * not supported on vertical calendar
+   */
+  with_full_screen_portal: PropTypes.bool,
+
+  /**
+   * Specifies what day is the first day of the week, values must be
+   * from [0, ..., 6] with 0 denoting Sunday and 6 denoting Saturday
+   */
+  first_day_of_week: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+
+  /**
+   * If True the calendar will not close when the user has selected a value
+   * and will wait until the user clicks off the calendar
+   */
+  stay_open_on_select: PropTypes.bool,
+
+  /**
+   * If True the calendar will display days that rollover into
+   * the next month
+   */
+  show_outside_days: PropTypes.bool,
+
+  /**
+   * Specifies the format that the month will be displayed in the calendar,
+   * valid formats are variations of "MM YY". For example:
+   * "MM YY" renders as '05 97' for May 1997
+   * "MMMM, YYYY" renders as 'May, 1997' for May 1997
+   * "MMM, YY" renders as 'Sep, 97' for September 1997
+   */
+  month_format: PropTypes.string,
+
+  /**
+   * Specifies the format that the selected dates will be displayed
+   * valid formats are variations of "MM YY DD". For example:
+   * "MM YY DD" renders as '05 10 97' for May 10th 1997
+   * "MMMM, YY" renders as 'May, 1997' for May 10th 1997
+   * "M, D, YYYY" renders as '07, 10, 1997' for September 10th 1997
+   * "MMMM" renders as 'May' for May 10 1997
+   */
+  display_format: PropTypes.string,
+
+  /**
+   * If True, no dates can be selected.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Whether or not the dropdown is "clearable", that is, whether or
+   * not a small "x" appears on the right of the dropdown that removes
+   * the selected value.
+   */
+  clearable: PropTypes.bool,
+
+  /**
+   * Dash-assigned callback that gets fired when the value changes.
+   */
+  setProps: PropTypes.func,
+
+  /**
+   * Dash-assigned callback that gets fired when the value changes.
+   */
+  dashEvents: PropTypes.oneOf(['change']),
+
+  fireEvent: PropTypes.func
+};
+
+DatePickerSingle.defaultProps = {
+  calendar_orientation: 'horizontal',
+  is_RTL: false,
+  day_size: 39,
+  with_portal: false,
+  with_full_screen_portal: false,
+  show_outside_days: true,
+  first_day_of_week: 0,
+  number_of_months_shown: 1,
+  stay_open_on_select: false,
+  reopen_calendar_on_clear: false,
+  clearable: false,
+  disabled: false
+};

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -31,7 +31,6 @@ export default class DatePickerSingle extends Component {
   }
 
   propsToState(newProps) {
-    console.log(R);
     /*
          * state includes:
          * - user modifiable attributes

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -3,7 +3,12 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
 import React, {Component} from 'react';
-import './react-dates@12.3.0.css'
+import './react-dates@12.3.0.css';
+
+const sizeMap = {
+  sm: 'date-picker-sm',
+  lg: 'date-picker-lg'
+};
 
 /**
  * DatePickerSingle is a tailor made component designed for selecting
@@ -102,35 +107,40 @@ export default class DatePickerSingle extends Component {
       show_outside_days,
       stay_open_on_select,
       with_full_screen_portal,
-      with_portal
+      with_portal,
+      bs_size
     } = this.props;
+
+    const sizeClass = sizeMap[bs_size];
 
     const verticalFlag = calendar_orientation !== 'vertical';
 
     return (
-      <SingleDatePicker
-        date={date}
-        onDateChange={this.onDateChange}
-        focused={focused}
-        onFocusChange={({focused}) => this.setState({focused})}
-        initialVisibleMonth={() => date || initial_visible_month}
-        isOutsideRange={this.isOutsideRange}
-        numberOfMonths={number_of_months_shown}
-        withPortal={with_portal && verticalFlag}
-        withFullScreenPortal={with_full_screen_portal && verticalFlag}
-        firstDayOfWeek={first_day_of_week}
-        enableOutsideDays={show_outside_days}
-        monthFormat={month_format}
-        displayFormat={display_format}
-        placeholder={placeholder}
-        showClearDate={clearable}
-        disabled={disabled}
-        keepOpenOnDateSelect={stay_open_on_select}
-        reopenPickerOnClearDate={reopen_calendar_on_clear}
-        isRTL={is_RTL}
-        orientation={calendar_orientation}
-        daySize={day_size}
-      />
+      <div className={sizeClass}>
+        <SingleDatePicker
+          date={date}
+          onDateChange={this.onDateChange}
+          focused={focused}
+          onFocusChange={({focused}) => this.setState({focused})}
+          initialVisibleMonth={() => date || initial_visible_month}
+          isOutsideRange={this.isOutsideRange}
+          numberOfMonths={number_of_months_shown}
+          withPortal={with_portal && verticalFlag}
+          withFullScreenPortal={with_full_screen_portal && verticalFlag}
+          firstDayOfWeek={first_day_of_week}
+          enableOutsideDays={show_outside_days}
+          monthFormat={month_format}
+          displayFormat={display_format}
+          placeholder={placeholder}
+          showClearDate={clearable}
+          disabled={disabled}
+          keepOpenOnDateSelect={stay_open_on_select}
+          reopenPickerOnClearDate={reopen_calendar_on_clear}
+          isRTL={is_RTL}
+          orientation={calendar_orientation}
+          daySize={day_size}
+        />
+      </div>
     );
   }
 }
@@ -271,6 +281,11 @@ DatePickerSingle.propTypes = {
    * Dash-assigned callback that gets fired when the value changes.
    */
   dashEvents: PropTypes.oneOf(['change']),
+
+  /**
+   * Set the size of the DatePickerSingle
+   */
+  bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
 
   fireEvent: PropTypes.func
 };

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -51,6 +51,10 @@ export default class DatePickerSingle extends Component {
         newState[prop].add(1, 'days');
       }
     });
+    const disabled_days = newProps['disabled_days'];
+    if (R.type(disabled_days) != 'Undefined') {
+      newState['disabled_days'] = disabled_days.map(d => moment(d));
+    }
     this.setState(newState);
   }
 
@@ -63,7 +67,7 @@ export default class DatePickerSingle extends Component {
   }
 
   isOutsideRange(date) {
-    const {min_date_allowed, max_date_allowed} = this.state;
+    const {min_date_allowed, max_date_allowed, disabled_days} = this.state;
 
     const notUndefined = R.complement(
       R.pipe(
@@ -73,7 +77,8 @@ export default class DatePickerSingle extends Component {
     );
     return (
       (notUndefined(min_date_allowed) && date < min_date_allowed) ||
-      (notUndefined(max_date_allowed) && date >= max_date_allowed)
+      (notUndefined(max_date_allowed) && date >= max_date_allowed) ||
+      (notUndefined(disabled_days) && disabled_days.some(d => d.isSame(date, 'day')))
     );
   }
 
@@ -286,6 +291,12 @@ DatePickerSingle.propTypes = {
    * Set the size of the DatePickerSingle
    */
   bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
+
+  /**
+   * A list of days to disable in addition to any that fall outside of the range
+   * specified by min_date_allowed and max_date_allowed.
+   */
+  disabled_days: PropTypes.arrayOf(PropTypes.string),
 
   fireEvent: PropTypes.func
 };

--- a/src/components/input/react-dates@12.3.0.css
+++ b/src/components/input/react-dates@12.3.0.css
@@ -1,0 +1,744 @@
+.CalendarDay {
+  border: 1px solid #e4e7e7;
+  padding: 0;
+  box-sizing: border-box;
+  color: #565a5c;
+  cursor: pointer; }
+
+.CalendarDay__button {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  box-sizing: border-box; }
+  .CalendarDay__button:active {
+    outline: 0; }
+
+.CalendarDay--highlighted-calendar {
+  background: #ffe8bc;
+  color: #565a5c;
+  cursor: default; }
+  .CalendarDay--highlighted-calendar:active {
+    background: #007a87; }
+
+.CalendarDay--outside {
+  border: 0;
+  cursor: default; }
+  .CalendarDay--outside:active {
+    background: #fff; }
+
+.CalendarDay--hovered {
+  background: #e4e7e7;
+  border: 1px double #d4d9d9;
+  color: inherit; }
+
+.CalendarDay--blocked-minimum-nights {
+  color: #cacccd;
+  background: #fff;
+  border: 1px solid #e4e7e7;
+  cursor: default; }
+  .CalendarDay--blocked-minimum-nights:active {
+    background: #fff; }
+
+.CalendarDay--selected-span {
+  background: #abe2fb;
+  border: 1px double #abe2fb;
+  color: #fff; }
+  .CalendarDay--selected-span.CalendarDay--hovered, .CalendarDay--selected-span:active {
+    background: #70d1ff;
+    border: 1px double #abe2fb; }
+  .CalendarDay--selected-span.CalendarDay--last-in-range {
+    border-right: #70d1ff; }
+
+.CalendarDay--hovered-span,
+.CalendarDay--after-hovered-start {
+  background: #b2f1ec;
+  border: 1px double #80e8e0;
+  color: #007a87; }
+  .CalendarDay--hovered-span:active,
+  .CalendarDay--after-hovered-start:active {
+    background: #80e8e0; }
+
+.CalendarDay--selected-start,
+.CalendarDay--selected-end,
+.CalendarDay--selected {
+  background: #70d1ff;
+  border: 1px double #70d1ff;
+  color: #fff; }
+  .CalendarDay--selected-start:active,
+  .CalendarDay--selected-end:active,
+  .CalendarDay--selected:active {
+    background: #70d1ff; }
+
+.CalendarDay--blocked-calendar {
+  background: #cacccd;
+  color: #82888a;
+  cursor: default; }
+  .CalendarDay--blocked-calendar:active {
+    background: #cacccd; }
+
+.CalendarDay--blocked-out-of-range {
+  color: #cacccd;
+  background: #fff;
+  border: 1px solid #e4e7e7;
+  cursor: default; }
+  .CalendarDay--blocked-out-of-range:active {
+    background: #fff; }
+
+.CalendarMonth {
+  text-align: center;
+  padding: 0 13px;
+  vertical-align: top;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+  .CalendarMonth table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    caption-caption-side: initial; }
+
+.CalendarMonth--horizontal:first-of-type,
+.CalendarMonth--vertical:first-of-type {
+  position: absolute;
+  z-index: -1;
+  opacity: 0;
+  pointer-events: none; }
+
+.CalendarMonth--horizontal {
+  display: inline-block;
+  min-height: 100%; }
+
+.CalendarMonth--vertical {
+  display: block; }
+
+.CalendarMonth__caption {
+  color: #3c3f40;
+  margin-top: 7px;
+  font-size: 18px;
+  text-align: center;
+  margin-bottom: 2px;
+  caption-side: initial; }
+
+.CalendarMonth--horizontal .CalendarMonth__caption,
+.CalendarMonth--vertical .CalendarMonth__caption {
+  padding: 15px 0 35px; }
+
+.CalendarMonth--vertical-scrollable .CalendarMonth__caption {
+  padding: 5px 0; }
+
+.CalendarMonthGrid {
+  background: #fff;
+  z-index: 0;
+  text-align: left; }
+
+.CalendarMonthGrid--animating {
+  -webkit-transition: -webkit-transform 0.2s ease-in-out;
+  -moz-transition: -moz-transform 0.2s ease-in-out;
+  transition: transform 0.2s ease-in-out;
+  z-index: 1; }
+
+.CalendarMonthGrid--horizontal {
+  position: absolute;
+  left: 9px; }
+
+.CalendarMonthGrid--vertical {
+  margin: 0 auto; }
+
+.CalendarMonthGrid--vertical-scrollable {
+  margin: 0 auto;
+  overflow-y: scroll; }
+
+.DayPicker {
+  background: #fff;
+  position: relative;
+  text-align: left; }
+
+.DayPicker--horizontal {
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.07);
+  border-radius: 3px; }
+  .DayPicker--horizontal.DayPicker--portal {
+    box-shadow: none;
+    position: absolute;
+    left: 50%;
+    top: 50%; }
+
+.DayPicker--vertical.DayPicker--portal {
+  position: initial; }
+
+.DayPicker__focus-region {
+  outline: none; }
+
+.DayPicker__week-headers {
+  position: relative; }
+
+.DayPicker--horizontal .DayPicker__week-headers {
+  margin-left: 9px; }
+
+.DayPicker__week-header {
+  color: #757575;
+  position: absolute;
+  top: 62px;
+  z-index: 2;
+  padding: 0 13px;
+  text-align: left; }
+  .DayPicker__week-header ul {
+    list-style: none;
+    margin: 1px 0;
+    padding-left: 0;
+    padding-right: 0; }
+  .DayPicker__week-header li {
+    display: inline-block;
+    text-align: center; }
+
+.DayPicker--vertical .DayPicker__week-header {
+  left: 50%; }
+
+.DayPicker--vertical-scrollable {
+  height: 100%; }
+  .DayPicker--vertical-scrollable .DayPicker__week-header {
+    top: 0;
+    display: table-row;
+    border-bottom: 1px solid #dbdbdb;
+    background: white; }
+  .DayPicker--vertical-scrollable .transition-container--vertical {
+    padding-top: 20px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    overflow-y: scroll; }
+  .DayPicker--vertical-scrollable .DayPicker__week-header {
+    margin-left: 0;
+    left: 0;
+    width: 100%;
+    text-align: center; }
+
+.transition-container {
+  position: relative;
+  overflow: hidden;
+  border-radius: 3px; }
+
+.transition-container--horizontal {
+  transition: height 0.2s ease-in-out; }
+
+.transition-container--vertical {
+  width: 100%; }
+
+.DayPickerNavigation__prev,
+.DayPickerNavigation__next {
+  cursor: pointer;
+  line-height: 0.78;
+  -webkit-user-select: none;
+  /* Chrome/Safari */
+  -moz-user-select: none;
+  /* Firefox */
+  -ms-user-select: none;
+  /* IE10+ */
+  user-select: none; }
+
+.DayPickerNavigation__prev--default,
+.DayPickerNavigation__next--default {
+  border: 1px solid #dce0e0;
+  background-color: #fff;
+  color: #757575; }
+  .DayPickerNavigation__prev--default:focus, .DayPickerNavigation__prev--default:hover,
+  .DayPickerNavigation__next--default:focus,
+  .DayPickerNavigation__next--default:hover {
+    border: 1px solid #c4c4c4; }
+  .DayPickerNavigation__prev--default:active,
+  .DayPickerNavigation__next--default:active {
+    background: #f2f2f2; }
+
+.DayPickerNavigation--horizontal {
+  position: relative; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__prev,
+  .DayPickerNavigation--horizontal .DayPickerNavigation__next {
+    border-radius: 3px;
+    padding: 6px 9px;
+    top: 18px;
+    z-index: 2;
+    position: absolute; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__prev {
+    left: 22px; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__prev--rtl {
+    left: auto;
+    right: 22px; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__next {
+    right: 22px; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__next--rtl {
+    right: auto;
+    left: 22px; }
+  .DayPickerNavigation--horizontal .DayPickerNavigation__prev--default svg,
+  .DayPickerNavigation--horizontal .DayPickerNavigation__next--default svg {
+    height: 19px;
+    width: 19px;
+    fill: #82888a; }
+
+.DayPickerNavigation--vertical {
+  background: #fff;
+  box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 52px;
+  width: 100%;
+  z-index: 2; }
+  .DayPickerNavigation--vertical .DayPickerNavigation__prev,
+  .DayPickerNavigation--vertical .DayPickerNavigation__next {
+    display: inline-block;
+    position: relative;
+    height: 100%;
+    width: 50%; }
+  .DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+    border-left: 0; }
+  .DayPickerNavigation--vertical .DayPickerNavigation__prev--default,
+  .DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+    text-align: center;
+    font-size: 2.5em;
+    padding: 5px; }
+    .DayPickerNavigation--vertical .DayPickerNavigation__prev--default svg,
+    .DayPickerNavigation--vertical .DayPickerNavigation__next--default svg {
+      height: 42px;
+      width: 42px;
+      fill: #484848; }
+
+.DayPickerNavigation--vertical-scrollable {
+  position: relative; }
+  .DayPickerNavigation--vertical-scrollable .DayPickerNavigation__next {
+    width: 100%; }
+
+.DayPickerKeyboardShortcuts__show,
+.DayPickerKeyboardShortcuts__close {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  cursor: pointer; }
+  .DayPickerKeyboardShortcuts__show:active,
+  .DayPickerKeyboardShortcuts__close:active {
+    outline: none; }
+
+.DayPickerKeyboardShortcuts__show {
+  width: 22px;
+  position: absolute;
+  z-index: 2; }
+
+.DayPickerKeyboardShortcuts__show--bottom-right {
+  border-top: 26px solid transparent;
+  border-right: 33px solid #70d1ff;
+  bottom: 0;
+  right: 0; }
+  .DayPickerKeyboardShortcuts__show--bottom-right:hover {
+    border-right: 33px solid #008489; }
+  .DayPickerKeyboardShortcuts__show--bottom-right .DayPickerKeyboardShortcuts__show_span {
+    bottom: 0;
+    right: -28px; }
+
+.DayPickerKeyboardShortcuts__show--top-right {
+  border-bottom: 26px solid transparent;
+  border-right: 33px solid #70d1ff;
+  top: 0;
+  right: 0; }
+  .DayPickerKeyboardShortcuts__show--top-right:hover {
+    border-right: 33px solid #008489; }
+  .DayPickerKeyboardShortcuts__show--top-right .DayPickerKeyboardShortcuts__show_span {
+    top: 1px;
+    right: -28px; }
+
+.DayPickerKeyboardShortcuts__show--top-left {
+  border-bottom: 26px solid transparent;
+  border-left: 33px solid #70d1ff;
+  top: 0;
+  left: 0; }
+  .DayPickerKeyboardShortcuts__show--top-left:hover {
+    border-left: 33px solid #008489; }
+  .DayPickerKeyboardShortcuts__show--top-left .DayPickerKeyboardShortcuts__show_span {
+    top: 1px;
+    left: -28px; }
+
+.DayPickerKeyboardShortcuts__show_span {
+  color: #fff;
+  position: absolute; }
+
+.DayPickerKeyboardShortcuts__panel {
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #dbdbdb;
+  border-radius: 2px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+  padding: 22px;
+  margin: 33px; }
+
+.DayPickerKeyboardShortcuts__title {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0; }
+
+.DayPickerKeyboardShortcuts__list {
+  list-style: none;
+  padding: 0; }
+
+.DayPickerKeyboardShortcuts__close {
+  position: absolute;
+  right: 22px;
+  top: 22px;
+  z-index: 2; }
+  .DayPickerKeyboardShortcuts__close svg {
+    height: 15px;
+    width: 15px;
+    fill: #cacccd; }
+    .DayPickerKeyboardShortcuts__close svg:hover, .DayPickerKeyboardShortcuts__close svg:focus {
+      fill: #82888a; }
+  .DayPickerKeyboardShortcuts__close:active {
+    outline: none; }
+
+.KeyboardShortcutRow {
+  margin: 6px 0; }
+
+.KeyboardShortcutRow__key-container {
+  display: inline-block;
+  white-space: nowrap;
+  text-align: right;
+  margin-right: 6px; }
+
+.KeyboardShortcutRow__key {
+  font-family: monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  background: #f2f2f2;
+  padding: 2px 6px; }
+
+.KeyboardShortcutRow__action {
+  display: inline;
+  word-break: break-word;
+  margin-left: 8px; }
+
+.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow {
+  margin-bottom: 16px; }
+
+.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__key-container {
+  width: auto;
+  text-align: left;
+  display: inline; }
+
+.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__action {
+  display: inline; }
+
+.DateInput {
+  font-weight: 200;
+  font-size: 18px;
+  line-height: 24px;
+  color: #757575;
+  margin: 0;
+  padding: 8px;
+  background: #fff;
+  position: relative;
+  display: inline-block;
+  width: 130px;
+  vertical-align: middle; }
+
+.DateInput--with-caret::before,
+.DateInput--with-caret::after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  bottom: auto;
+  border: 10px solid transparent;
+  border-top: 0;
+  left: 22px;
+  z-index: 2; }
+
+.DateInput--with-caret::before {
+  top: 62px;
+  border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+.DateInput--with-caret::after {
+  top: 63px;
+  border-bottom-color: #fff; }
+
+.DateInput--disabled {
+  background: #cacccd; }
+
+.DateInput__input {
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+  height: 100%;
+  width: 100%; }
+  .DateInput__input[readonly] {
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none; }
+
+.DateInput__display-text {
+  padding: 4px 8px;
+  white-space: nowrap;
+  overflow: hidden; }
+
+.DateInput__display-text--has-input {
+  color: #484848; }
+
+.DateInput__display-text--focused {
+  background: rgba(212, 241, 255, 0.7);
+  border-color: rgba(212, 241, 255, 0.7);
+  border-radius: 3px;
+  color: #007a87; }
+
+.DateInput__display-text--disabled {
+  font-style: italic; }
+
+.screen-reader-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; }
+
+.DateRangePicker {
+  position: relative;
+  display: inline-block; }
+
+.DateRangePicker__picker {
+  z-index: 1;
+  background-color: #fff;
+  position: absolute;
+  top: 72px; }
+
+.DateRangePicker__picker--rtl {
+  direction: rtl; }
+
+.DateRangePicker__picker--direction-left {
+  left: 0; }
+
+.DateRangePicker__picker--direction-right {
+  right: 0; }
+
+.DateRangePicker__picker--portal {
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%; }
+
+.DateRangePicker__picker--full-screen-portal {
+  background-color: #fff; }
+
+.DateRangePicker__close {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 15px;
+  z-index: 2; }
+  .DateRangePicker__close svg {
+    height: 15px;
+    width: 15px;
+    fill: #cacccd; }
+  .DateRangePicker__close:hover, .DateRangePicker__close:focus {
+    color: #b0b3b4;
+    text-decoration: none; }
+
+.DateRangePickerInput {
+  background-color: #fff;
+  border: 1px solid #cacccd;
+  display: inline-block; }
+
+.DateRangePickerInput--disabled {
+  background: #cacccd; }
+
+.DateRangePickerInput--rtl {
+  direction: rtl; }
+
+.DateRangePickerInput__arrow {
+  display: inline-block;
+  vertical-align: middle; }
+
+.DateRangePickerInput__arrow svg {
+  vertical-align: middle;
+  fill: #484848;
+  height: 24px;
+  width: 24px; }
+
+.DateRangePickerInput__clear-dates {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 10px 0 5px; }
+
+.DateRangePickerInput__clear-dates svg {
+  fill: #82888a;
+  height: 12px;
+  width: 15px;
+  vertical-align: middle; }
+
+.DateRangePickerInput__clear-dates--hide {
+  visibility: hidden; }
+
+.DateRangePickerInput__clear-dates:focus,
+.DateRangePickerInput__clear-dates--hover {
+  background: #dbdbdb;
+  border-radius: 50%; }
+
+.DateRangePickerInput__calendar-icon {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 5px 0 10px; }
+  .DateRangePickerInput__calendar-icon svg {
+    fill: #82888a;
+    height: 15px;
+    width: 14px;
+    vertical-align: middle; }
+
+.SingleDatePicker {
+  position: relative;
+  display: inline-block; }
+
+.SingleDatePicker__picker {
+  z-index: 1;
+  background-color: #fff;
+  position: absolute;
+  top: 72px; }
+
+.SingleDatePicker__picker--rtl {
+  direction: rtl; }
+
+.SingleDatePicker__picker--direction-left {
+  left: 0; }
+
+.SingleDatePicker__picker--direction-right {
+  right: 0; }
+
+.SingleDatePicker__picker--portal {
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%; }
+
+.SingleDatePicker__picker--full-screen-portal {
+  background-color: #fff; }
+
+.SingleDatePicker__close {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 15px;
+  z-index: 2; }
+  .SingleDatePicker__close svg {
+    height: 15px;
+    width: 15px;
+    fill: #cacccd; }
+  .SingleDatePicker__close:hover, .SingleDatePicker__close:focus {
+    color: #b0b3b4;
+    text-decoration: none; }
+
+.SingleDatePickerInput {
+  background-color: #fff;
+  border: 1px solid #dbdbdb; }
+
+.SingleDatePickerInput--rtl {
+  direction: rtl; }
+
+.SingleDatePickerInput__clear-date {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 10px 0 5px; }
+
+.SingleDatePickerInput__clear-date svg {
+  fill: #82888a;
+  height: 12px;
+  width: 15px;
+  vertical-align: middle; }
+
+.SingleDatePickerInput__clear-date--hide {
+  visibility: hidden; }
+
+.SingleDatePickerInput__clear-date:focus,
+.SingleDatePickerInput__clear-date--hover {
+  background: #dbdbdb;
+  border-radius: 50%; }
+
+.SingleDatePickerInput__calendar-icon {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 5px 0 10px; }
+  .SingleDatePickerInput__calendar-icon svg {
+    fill: #82888a;
+    height: 15px;
+    width: 14px;
+    vertical-align: middle; }

--- a/src/components/input/react-dates@12.3.0.css
+++ b/src/components/input/react-dates@12.3.0.css
@@ -1,5 +1,33 @@
-.form-group > .SingleDatePicker, .form-group > .DateRangePicker {
+.form-group>.SingleDatePicker, .form-group>.DateRangePicker {
   display: table;
+}
+
+.date-picker-sm .SingleDatePickerInput {
+  height: calc(1.8125rem + 2px);
+  font-size: .875rem;
+  line-height: 1.5;
+  border-radius: .2rem;
+}
+
+.date-picker-sm .DateInput {
+  font-size: .875rem;
+  line-height: 1.5;
+  padding: 0 .5rem;
+  width: 110px;
+}
+
+.date-picker-lg .SingleDatePickerInput {
+  height: calc(2.875rem + 2px);
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: .3rem;
+}
+
+.date-picker-lg .DateInput {
+  font-size: 1.25rem;
+  line-height: 1.5;
+  padding: .25rem 1rem;
+  width: 150px;
 }
 
 .CalendarDay {
@@ -7,7 +35,8 @@
   padding: 0;
   box-sizing: border-box;
   color: #565a5c;
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 .CalendarDay__button {
   position: relative;
@@ -23,80 +52,110 @@
   line-height: normal;
   overflow: visible;
   cursor: pointer;
-  box-sizing: border-box; }
-  .CalendarDay__button:active {
-    outline: 0; }
+  box-sizing: border-box;
+}
+
+.CalendarDay__button:active {
+  outline: 0;
+}
 
 .CalendarDay--highlighted-calendar {
   background: #ffe8bc;
   color: #565a5c;
-  cursor: default; }
-  .CalendarDay--highlighted-calendar:active {
-    background: #007a87; }
+  cursor: default;
+}
+
+.CalendarDay--highlighted-calendar:active {
+  background: #007a87;
+}
 
 .CalendarDay--outside {
   border: 0;
-  cursor: default; }
-  .CalendarDay--outside:active {
-    background: #fff; }
+  cursor: default;
+}
+
+.CalendarDay--outside:active {
+  background: #fff;
+}
 
 .CalendarDay--hovered {
   background: #e4e7e7;
   border: 1px double #d4d9d9;
-  color: inherit; }
+  color: inherit;
+}
 
 .CalendarDay--blocked-minimum-nights {
   color: #cacccd;
   background: #fff;
   border: 1px solid #e4e7e7;
-  cursor: default; }
-  .CalendarDay--blocked-minimum-nights:active {
-    background: #fff; }
+  cursor: default;
+}
+
+.CalendarDay--blocked-minimum-nights:active {
+  background: #fff;
+}
 
 .CalendarDay--selected-span {
   background: #abe2fb;
   border: 1px double #abe2fb;
-  color: #fff; }
-  .CalendarDay--selected-span.CalendarDay--hovered, .CalendarDay--selected-span:active {
-    background: #70d1ff;
-    border: 1px double #abe2fb; }
-  .CalendarDay--selected-span.CalendarDay--last-in-range {
-    border-right: #70d1ff; }
+  color: #fff;
+}
+
+.CalendarDay--selected-span.CalendarDay--hovered, .CalendarDay--selected-span:active {
+  background: #70d1ff;
+  border: 1px double #abe2fb;
+}
+
+.CalendarDay--selected-span.CalendarDay--last-in-range {
+  border-right: #70d1ff;
+}
 
 .CalendarDay--hovered-span,
 .CalendarDay--after-hovered-start {
   background: #b2f1ec;
   border: 1px double #80e8e0;
-  color: #007a87; }
-  .CalendarDay--hovered-span:active,
-  .CalendarDay--after-hovered-start:active {
-    background: #80e8e0; }
+  color: #007a87;
+}
+
+.CalendarDay--hovered-span:active,
+.CalendarDay--after-hovered-start:active {
+  background: #80e8e0;
+}
 
 .CalendarDay--selected-start,
 .CalendarDay--selected-end,
 .CalendarDay--selected {
   background: #70d1ff;
   border: 1px double #70d1ff;
-  color: #fff; }
-  .CalendarDay--selected-start:active,
-  .CalendarDay--selected-end:active,
-  .CalendarDay--selected:active {
-    background: #70d1ff; }
+  color: #fff;
+}
+
+.CalendarDay--selected-start:active,
+.CalendarDay--selected-end:active,
+.CalendarDay--selected:active {
+  background: #70d1ff;
+}
 
 .CalendarDay--blocked-calendar {
   background: #cacccd;
   color: #82888a;
-  cursor: default; }
-  .CalendarDay--blocked-calendar:active {
-    background: #cacccd; }
+  cursor: default;
+}
+
+.CalendarDay--blocked-calendar:active {
+  background: #cacccd;
+}
 
 .CalendarDay--blocked-out-of-range {
   color: #cacccd;
   background: #fff;
   border: 1px solid #e4e7e7;
-  cursor: default; }
-  .CalendarDay--blocked-out-of-range:active {
-    background: #fff; }
+  cursor: default;
+}
+
+.CalendarDay--blocked-out-of-range:active {
+  background: #fff;
+}
 
 .CalendarMonth {
   text-align: center;
@@ -105,25 +164,31 @@
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
-  user-select: none; }
-  .CalendarMonth table {
-    border-collapse: collapse;
-    border-spacing: 0;
-    caption-caption-side: initial; }
+  user-select: none;
+}
+
+.CalendarMonth table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  caption-caption-side: initial;
+}
 
 .CalendarMonth--horizontal:first-of-type,
 .CalendarMonth--vertical:first-of-type {
   position: absolute;
   z-index: -1;
   opacity: 0;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
 .CalendarMonth--horizontal {
   display: inline-block;
-  min-height: 100%; }
+  min-height: 100%;
+}
 
 .CalendarMonth--vertical {
-  display: block; }
+  display: block;
+}
 
 .CalendarMonth__caption {
   color: #3c3f40;
@@ -131,63 +196,79 @@
   font-size: 18px;
   text-align: center;
   margin-bottom: 2px;
-  caption-side: initial; }
+  caption-side: initial;
+}
 
 .CalendarMonth--horizontal .CalendarMonth__caption,
 .CalendarMonth--vertical .CalendarMonth__caption {
-  padding: 15px 0 35px; }
+  padding: 15px 0 35px;
+}
 
 .CalendarMonth--vertical-scrollable .CalendarMonth__caption {
-  padding: 5px 0; }
+  padding: 5px 0;
+}
 
 .CalendarMonthGrid {
   background: #fff;
   z-index: 0;
-  text-align: left; }
+  text-align: left;
+}
 
 .CalendarMonthGrid--animating {
   -webkit-transition: -webkit-transform 0.2s ease-in-out;
   -moz-transition: -moz-transform 0.2s ease-in-out;
   transition: transform 0.2s ease-in-out;
-  z-index: 1; }
+  z-index: 1;
+}
 
 .CalendarMonthGrid--horizontal {
   position: absolute;
-  left: 9px; }
+  left: 9px;
+}
 
 .CalendarMonthGrid--vertical {
-  margin: 0 auto; }
+  margin: 0 auto;
+}
 
 .CalendarMonthGrid--vertical-scrollable {
   margin: 0 auto;
-  overflow-y: scroll; }
+  overflow-y: scroll;
+}
 
 .DayPicker {
   background: #fff;
   position: relative;
-  text-align: left; }
+  text-align: left;
+}
 
 .DayPicker--horizontal {
   background: #fff;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.07);
-  border-radius: 3px; }
-  .DayPicker--horizontal.DayPicker--portal {
-    box-shadow: none;
-    position: absolute;
-    left: 50%;
-    top: 50%; }
+  border-radius: 3px;
+}
+
+.DayPicker--horizontal.DayPicker--portal {
+  box-shadow: none;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+}
 
 .DayPicker--vertical.DayPicker--portal {
-  position: initial; }
+  position: initial;
+}
 
 .DayPicker__focus-region {
-  outline: none; }
+  outline: none;
+}
 
 .DayPicker__week-headers {
-  position: relative; }
+  position: relative;
+}
 
 .DayPicker--horizontal .DayPicker__week-headers {
-  margin-left: 9px; }
+  margin-left: 9px;
+}
 
 .DayPicker__week-header {
   color: #757575;
@@ -195,51 +276,67 @@
   top: 62px;
   z-index: 2;
   padding: 0 13px;
-  text-align: left; }
-  .DayPicker__week-header ul {
-    list-style: none;
-    margin: 1px 0;
-    padding-left: 0;
-    padding-right: 0; }
-  .DayPicker__week-header li {
-    display: inline-block;
-    text-align: center; }
+  text-align: left;
+}
+
+.DayPicker__week-header ul {
+  list-style: none;
+  margin: 1px 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.DayPicker__week-header li {
+  display: inline-block;
+  text-align: center;
+}
 
 .DayPicker--vertical .DayPicker__week-header {
-  left: 50%; }
+  left: 50%;
+}
 
 .DayPicker--vertical-scrollable {
-  height: 100%; }
-  .DayPicker--vertical-scrollable .DayPicker__week-header {
-    top: 0;
-    display: table-row;
-    border-bottom: 1px solid #dbdbdb;
-    background: white; }
-  .DayPicker--vertical-scrollable .transition-container--vertical {
-    padding-top: 20px;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    left: 0;
-    overflow-y: scroll; }
-  .DayPicker--vertical-scrollable .DayPicker__week-header {
-    margin-left: 0;
-    left: 0;
-    width: 100%;
-    text-align: center; }
+  height: 100%;
+}
+
+.DayPicker--vertical-scrollable .DayPicker__week-header {
+  top: 0;
+  display: table-row;
+  border-bottom: 1px solid #dbdbdb;
+  background: white;
+}
+
+.DayPicker--vertical-scrollable .transition-container--vertical {
+  padding-top: 20px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  overflow-y: scroll;
+}
+
+.DayPicker--vertical-scrollable .DayPicker__week-header {
+  margin-left: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
 
 .transition-container {
   position: relative;
   overflow: hidden;
-  border-radius: 3px; }
+  border-radius: 3px;
+}
 
 .transition-container--horizontal {
-  transition: height 0.2s ease-in-out; }
+  transition: height 0.2s ease-in-out;
+}
 
 .transition-container--vertical {
-  width: 100%; }
+  width: 100%;
+}
 
 .DayPickerNavigation__prev,
 .DayPickerNavigation__next {
@@ -251,45 +348,64 @@
   /* Firefox */
   -ms-user-select: none;
   /* IE10+ */
-  user-select: none; }
+  user-select: none;
+}
 
 .DayPickerNavigation__prev--default,
 .DayPickerNavigation__next--default {
   border: 1px solid #dce0e0;
   background-color: #fff;
-  color: #757575; }
-  .DayPickerNavigation__prev--default:focus, .DayPickerNavigation__prev--default:hover,
-  .DayPickerNavigation__next--default:focus,
-  .DayPickerNavigation__next--default:hover {
-    border: 1px solid #c4c4c4; }
-  .DayPickerNavigation__prev--default:active,
-  .DayPickerNavigation__next--default:active {
-    background: #f2f2f2; }
+  color: #757575;
+}
+
+.DayPickerNavigation__prev--default:focus, .DayPickerNavigation__prev--default:hover,
+.DayPickerNavigation__next--default:focus,
+.DayPickerNavigation__next--default:hover {
+  border: 1px solid #c4c4c4;
+}
+
+.DayPickerNavigation__prev--default:active,
+.DayPickerNavigation__next--default:active {
+  background: #f2f2f2;
+}
 
 .DayPickerNavigation--horizontal {
-  position: relative; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__prev,
-  .DayPickerNavigation--horizontal .DayPickerNavigation__next {
-    border-radius: 3px;
-    padding: 6px 9px;
-    top: 18px;
-    z-index: 2;
-    position: absolute; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__prev {
-    left: 22px; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__prev--rtl {
-    left: auto;
-    right: 22px; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__next {
-    right: 22px; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__next--rtl {
-    right: auto;
-    left: 22px; }
-  .DayPickerNavigation--horizontal .DayPickerNavigation__prev--default svg,
-  .DayPickerNavigation--horizontal .DayPickerNavigation__next--default svg {
-    height: 19px;
-    width: 19px;
-    fill: #82888a; }
+  position: relative;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__prev,
+.DayPickerNavigation--horizontal .DayPickerNavigation__next {
+  border-radius: 3px;
+  padding: 6px 9px;
+  top: 18px;
+  z-index: 2;
+  position: absolute;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__prev {
+  left: 22px;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__prev--rtl {
+  left: auto;
+  right: 22px;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__next {
+  right: 22px;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__next--rtl {
+  right: auto;
+  left: 22px;
+}
+
+.DayPickerNavigation--horizontal .DayPickerNavigation__prev--default svg,
+.DayPickerNavigation--horizontal .DayPickerNavigation__next--default svg {
+  height: 19px;
+  width: 19px;
+  fill: #82888a;
+}
 
 .DayPickerNavigation--vertical {
   background: #fff;
@@ -299,30 +415,42 @@
   left: 0;
   height: 52px;
   width: 100%;
-  z-index: 2; }
-  .DayPickerNavigation--vertical .DayPickerNavigation__prev,
-  .DayPickerNavigation--vertical .DayPickerNavigation__next {
-    display: inline-block;
-    position: relative;
-    height: 100%;
-    width: 50%; }
-  .DayPickerNavigation--vertical .DayPickerNavigation__next--default {
-    border-left: 0; }
-  .DayPickerNavigation--vertical .DayPickerNavigation__prev--default,
-  .DayPickerNavigation--vertical .DayPickerNavigation__next--default {
-    text-align: center;
-    font-size: 2.5em;
-    padding: 5px; }
-    .DayPickerNavigation--vertical .DayPickerNavigation__prev--default svg,
-    .DayPickerNavigation--vertical .DayPickerNavigation__next--default svg {
-      height: 42px;
-      width: 42px;
-      fill: #484848; }
+  z-index: 2;
+}
+
+.DayPickerNavigation--vertical .DayPickerNavigation__prev,
+.DayPickerNavigation--vertical .DayPickerNavigation__next {
+  display: inline-block;
+  position: relative;
+  height: 100%;
+  width: 50%;
+}
+
+.DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+  border-left: 0;
+}
+
+.DayPickerNavigation--vertical .DayPickerNavigation__prev--default,
+.DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+  text-align: center;
+  font-size: 2.5em;
+  padding: 5px;
+}
+
+.DayPickerNavigation--vertical .DayPickerNavigation__prev--default svg,
+.DayPickerNavigation--vertical .DayPickerNavigation__next--default svg {
+  height: 42px;
+  width: 42px;
+  fill: #484848;
+}
 
 .DayPickerNavigation--vertical-scrollable {
-  position: relative; }
-  .DayPickerNavigation--vertical-scrollable .DayPickerNavigation__next {
-    width: 100%; }
+  position: relative;
+}
+
+.DayPickerNavigation--vertical-scrollable .DayPickerNavigation__next {
+  width: 100%;
+}
 
 .DayPickerKeyboardShortcuts__show,
 .DayPickerKeyboardShortcuts__close {
@@ -333,52 +461,72 @@
   line-height: normal;
   overflow: visible;
   padding: 0;
-  cursor: pointer; }
-  .DayPickerKeyboardShortcuts__show:active,
-  .DayPickerKeyboardShortcuts__close:active {
-    outline: none; }
+  cursor: pointer;
+}
+
+.DayPickerKeyboardShortcuts__show:active,
+.DayPickerKeyboardShortcuts__close:active {
+  outline: none;
+}
 
 .DayPickerKeyboardShortcuts__show {
   width: 22px;
   position: absolute;
-  z-index: 2; }
+  z-index: 2;
+}
 
 .DayPickerKeyboardShortcuts__show--bottom-right {
   border-top: 26px solid transparent;
   border-right: 33px solid #70d1ff;
   bottom: 0;
-  right: 0; }
-  .DayPickerKeyboardShortcuts__show--bottom-right:hover {
-    border-right: 33px solid #008489; }
-  .DayPickerKeyboardShortcuts__show--bottom-right .DayPickerKeyboardShortcuts__show_span {
-    bottom: 0;
-    right: -28px; }
+  right: 0;
+}
+
+.DayPickerKeyboardShortcuts__show--bottom-right:hover {
+  border-right: 33px solid #008489;
+}
+
+.DayPickerKeyboardShortcuts__show--bottom-right .DayPickerKeyboardShortcuts__show_span {
+  bottom: 0;
+  right: -28px;
+}
 
 .DayPickerKeyboardShortcuts__show--top-right {
   border-bottom: 26px solid transparent;
   border-right: 33px solid #70d1ff;
   top: 0;
-  right: 0; }
-  .DayPickerKeyboardShortcuts__show--top-right:hover {
-    border-right: 33px solid #008489; }
-  .DayPickerKeyboardShortcuts__show--top-right .DayPickerKeyboardShortcuts__show_span {
-    top: 1px;
-    right: -28px; }
+  right: 0;
+}
+
+.DayPickerKeyboardShortcuts__show--top-right:hover {
+  border-right: 33px solid #008489;
+}
+
+.DayPickerKeyboardShortcuts__show--top-right .DayPickerKeyboardShortcuts__show_span {
+  top: 1px;
+  right: -28px;
+}
 
 .DayPickerKeyboardShortcuts__show--top-left {
   border-bottom: 26px solid transparent;
   border-left: 33px solid #70d1ff;
   top: 0;
-  left: 0; }
-  .DayPickerKeyboardShortcuts__show--top-left:hover {
-    border-left: 33px solid #008489; }
-  .DayPickerKeyboardShortcuts__show--top-left .DayPickerKeyboardShortcuts__show_span {
-    top: 1px;
-    left: -28px; }
+  left: 0;
+}
+
+.DayPickerKeyboardShortcuts__show--top-left:hover {
+  border-left: 33px solid #008489;
+}
+
+.DayPickerKeyboardShortcuts__show--top-left .DayPickerKeyboardShortcuts__show_span {
+  top: 1px;
+  left: -28px;
+}
 
 .DayPickerKeyboardShortcuts__show_span {
   color: #fff;
-  position: absolute; }
+  position: absolute;
+}
 
 .DayPickerKeyboardShortcuts__panel {
   overflow: auto;
@@ -392,75 +540,94 @@
   left: 0;
   z-index: 2;
   padding: 22px;
-  margin: 33px; }
+  margin: 33px;
+}
 
 .DayPickerKeyboardShortcuts__title {
   font-size: 16px;
   font-weight: bold;
-  margin: 0; }
+  margin: 0;
+}
 
 .DayPickerKeyboardShortcuts__list {
   list-style: none;
-  padding: 0; }
+  padding: 0;
+}
 
 .DayPickerKeyboardShortcuts__close {
   position: absolute;
   right: 22px;
   top: 22px;
-  z-index: 2; }
-  .DayPickerKeyboardShortcuts__close svg {
-    height: 15px;
-    width: 15px;
-    fill: #cacccd; }
-    .DayPickerKeyboardShortcuts__close svg:hover, .DayPickerKeyboardShortcuts__close svg:focus {
-      fill: #82888a; }
-  .DayPickerKeyboardShortcuts__close:active {
-    outline: none; }
+  z-index: 2;
+}
+
+.DayPickerKeyboardShortcuts__close svg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}
+
+.DayPickerKeyboardShortcuts__close svg:hover, .DayPickerKeyboardShortcuts__close svg:focus {
+  fill: #82888a;
+}
+
+.DayPickerKeyboardShortcuts__close:active {
+  outline: none;
+}
 
 .KeyboardShortcutRow {
-  margin: 6px 0; }
+  margin: 6px 0;
+}
 
 .KeyboardShortcutRow__key-container {
   display: inline-block;
   white-space: nowrap;
   text-align: right;
-  margin-right: 6px; }
+  margin-right: 6px;
+}
 
 .KeyboardShortcutRow__key {
   font-family: monospace;
   font-size: 12px;
   text-transform: uppercase;
   background: #f2f2f2;
-  padding: 2px 6px; }
+  padding: 2px 6px;
+}
 
 .KeyboardShortcutRow__action {
   display: inline;
   word-break: break-word;
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow {
-  margin-bottom: 16px; }
+  margin-bottom: 16px;
+}
 
 .DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__key-container {
   width: auto;
   text-align: left;
-  display: inline; }
+  display: inline;
+}
 
 .DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__action {
-  display: inline; }
+  display: inline;
+}
 
 .DateInput {
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: .125rem .75rem;
+  border-radius: .25rem;
   font-weight: 200;
-  font-size: 18px;
-  line-height: 24px;
   color: #757575;
   margin: 0;
-  padding: 8px;
   background: #fff;
   position: relative;
   display: inline-block;
   width: 130px;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .DateInput--with-caret::before,
 .DateInput--with-caret::after {
@@ -471,18 +638,22 @@
   border: 10px solid transparent;
   border-top: 0;
   left: 22px;
-  z-index: 2; }
+  z-index: 2;
+}
 
 .DateInput--with-caret::before {
   top: 62px;
-  border-bottom-color: rgba(0, 0, 0, 0.1); }
+  border-bottom-color: rgba(0, 0, 0, 0.1);
+}
 
 .DateInput--with-caret::after {
   top: 63px;
-  border-bottom-color: #fff; }
+  border-bottom-color: #fff;
+}
 
 .DateInput--disabled {
-  background: #cacccd; }
+  background: #cacccd;
+}
 
 .DateInput__input {
   opacity: 0;
@@ -491,29 +662,36 @@
   left: 0;
   border: 0;
   height: 100%;
-  width: 100%; }
-  .DateInput__input[readonly] {
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none; }
+  width: 100%;
+}
+
+.DateInput__input[readonly] {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
 .DateInput__display-text {
   padding: 4px 8px;
   white-space: nowrap;
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 .DateInput__display-text--has-input {
-  color: #484848; }
+  color: #484848;
+}
 
 .DateInput__display-text--focused {
   background: rgba(212, 241, 255, 0.7);
   border-color: rgba(212, 241, 255, 0.7);
   border-radius: 3px;
-  color: #007a87; }
+  color: #007a87;
+}
 
 .DateInput__display-text--disabled {
-  font-style: italic; }
+  font-style: italic;
+}
 
 .screen-reader-only {
   border: 0;
@@ -523,26 +701,32 @@
   overflow: hidden;
   padding: 0;
   position: absolute;
-  width: 1px; }
+  width: 1px;
+}
 
 .DateRangePicker {
   position: relative;
-  display: inline-block; }
+  display: inline-block;
+}
 
 .DateRangePicker__picker {
   z-index: 1;
   background-color: #fff;
   position: absolute;
-  top: 72px; }
+  top: 72px;
+}
 
 .DateRangePicker__picker--rtl {
-  direction: rtl; }
+  direction: rtl;
+}
 
 .DateRangePicker__picker--direction-left {
-  left: 0; }
+  left: 0;
+}
 
 .DateRangePicker__picker--direction-right {
-  right: 0; }
+  right: 0;
+}
 
 .DateRangePicker__picker--portal {
   background-color: rgba(0, 0, 0, 0.3);
@@ -550,10 +734,12 @@
   top: 0;
   left: 0;
   height: 100%;
-  width: 100%; }
+  width: 100%;
+}
 
 .DateRangePicker__picker--full-screen-portal {
-  background-color: #fff; }
+  background-color: #fff;
+}
 
 .DateRangePicker__close {
   background: none;
@@ -568,35 +754,45 @@
   top: 0;
   right: 0;
   padding: 15px;
-  z-index: 2; }
-  .DateRangePicker__close svg {
-    height: 15px;
-    width: 15px;
-    fill: #cacccd; }
-  .DateRangePicker__close:hover, .DateRangePicker__close:focus {
-    color: #b0b3b4;
-    text-decoration: none; }
+  z-index: 2;
+}
+
+.DateRangePicker__close svg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}
+
+.DateRangePicker__close:hover, .DateRangePicker__close:focus {
+  color: #b0b3b4;
+  text-decoration: none;
+}
 
 .DateRangePickerInput {
   background-color: #fff;
   border: 1px solid #cacccd;
-  display: inline-block; }
+  display: inline-block;
+}
 
 .DateRangePickerInput--disabled {
-  background: #cacccd; }
+  background: #cacccd;
+}
 
 .DateRangePickerInput--rtl {
-  direction: rtl; }
+  direction: rtl;
+}
 
 .DateRangePickerInput__arrow {
   display: inline-block;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .DateRangePickerInput__arrow svg {
   vertical-align: middle;
   fill: #484848;
   height: 24px;
-  width: 24px; }
+  width: 24px;
+}
 
 .DateRangePickerInput__clear-dates {
   background: none;
@@ -609,21 +805,25 @@
   display: inline-block;
   vertical-align: middle;
   padding: 10px;
-  margin: 0 10px 0 5px; }
+  margin: 0 10px 0 5px;
+}
 
 .DateRangePickerInput__clear-dates svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .DateRangePickerInput__clear-dates--hide {
-  visibility: hidden; }
+  visibility: hidden;
+}
 
 .DateRangePickerInput__clear-dates:focus,
 .DateRangePickerInput__clear-dates--hover {
   background: #dbdbdb;
-  border-radius: 50%; }
+  border-radius: 50%;
+}
 
 .DateRangePickerInput__calendar-icon {
   background: none;
@@ -636,31 +836,39 @@
   display: inline-block;
   vertical-align: middle;
   padding: 10px;
-  margin: 0 5px 0 10px; }
-  .DateRangePickerInput__calendar-icon svg {
-    fill: #82888a;
-    height: 15px;
-    width: 14px;
-    vertical-align: middle; }
+  margin: 0 5px 0 10px;
+}
+
+.DateRangePickerInput__calendar-icon svg {
+  fill: #82888a;
+  height: 15px;
+  width: 14px;
+  vertical-align: middle;
+}
 
 .SingleDatePicker {
   position: relative;
-  display: inline-block; }
+  display: inline-block;
+}
 
 .SingleDatePicker__picker {
   z-index: 1;
   background-color: #fff;
   position: absolute;
-  top: 72px; }
+  top: 72px;
+}
 
 .SingleDatePicker__picker--rtl {
-  direction: rtl; }
+  direction: rtl;
+}
 
 .SingleDatePicker__picker--direction-left {
-  left: 0; }
+  left: 0;
+}
 
 .SingleDatePicker__picker--direction-right {
-  right: 0; }
+  right: 0;
+}
 
 .SingleDatePicker__picker--portal {
   background-color: rgba(0, 0, 0, 0.3);
@@ -668,10 +876,12 @@
   top: 0;
   left: 0;
   height: 100%;
-  width: 100%; }
+  width: 100%;
+}
 
 .SingleDatePicker__picker--full-screen-portal {
-  background-color: #fff; }
+  background-color: #fff;
+}
 
 .SingleDatePicker__close {
   background: none;
@@ -686,21 +896,36 @@
   top: 0;
   right: 0;
   padding: 15px;
-  z-index: 2; }
-  .SingleDatePicker__close svg {
-    height: 15px;
-    width: 15px;
-    fill: #cacccd; }
-  .SingleDatePicker__close:hover, .SingleDatePicker__close:focus {
-    color: #b0b3b4;
-    text-decoration: none; }
+  z-index: 2;
+}
+
+.SingleDatePicker__close svg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}
+
+.SingleDatePicker__close:hover, .SingleDatePicker__close:focus {
+  color: #b0b3b4;
+  text-decoration: none;
+}
 
 .SingleDatePickerInput {
+  border: 1px solid #ced4da;
   background-color: #fff;
-  border: 1px solid #dbdbdb; }
+  border-radius: .25rem;
+  height: calc(2.25rem + 2px);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #495057;
+  background-clip: padding-box;
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+  /* background-color: #fff;border: 1px solid #dbdbdb; */
+}
 
 .SingleDatePickerInput--rtl {
-  direction: rtl; }
+  direction: rtl;
+}
 
 .SingleDatePickerInput__clear-date {
   background: none;
@@ -713,21 +938,25 @@
   display: inline-block;
   vertical-align: middle;
   padding: 10px;
-  margin: 0 10px 0 5px; }
+  margin: 0 10px 0 5px;
+}
 
 .SingleDatePickerInput__clear-date svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .SingleDatePickerInput__clear-date--hide {
-  visibility: hidden; }
+  visibility: hidden;
+}
 
 .SingleDatePickerInput__clear-date:focus,
 .SingleDatePickerInput__clear-date--hover {
   background: #dbdbdb;
-  border-radius: 50%; }
+  border-radius: 50%;
+}
 
 .SingleDatePickerInput__calendar-icon {
   background: none;
@@ -740,9 +969,12 @@
   display: inline-block;
   vertical-align: middle;
   padding: 10px;
-  margin: 0 5px 0 10px; }
-  .SingleDatePickerInput__calendar-icon svg {
-    fill: #82888a;
-    height: 15px;
-    width: 14px;
-    vertical-align: middle; }
+  margin: 0 5px 0 10px;
+}
+
+.SingleDatePickerInput__calendar-icon svg {
+  fill: #82888a;
+  height: 15px;
+  width: 14px;
+  vertical-align: middle;
+}

--- a/src/components/input/react-dates@12.3.0.css
+++ b/src/components/input/react-dates@12.3.0.css
@@ -2,28 +2,59 @@
   display: table;
 }
 
-.date-picker-sm .SingleDatePickerInput {
+.dbc-datepicker .SingleDatePickerInput {
+  border: 1px solid #ced4da;
+  background-color: #fff;
+  border-radius: .25rem;
+  height: calc(2.25rem + 2px);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #495057;
+  background-clip: padding-box;
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+}
+
+.dbc-datepicker .DateRangePickerInput {
+  border: 1px solid #ced4da;
+  border-radius: .25rem;
+  height: calc(2.25rem + 2px);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #495057;
+  background-clip: padding-box;
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+}
+
+.dbc-datepicker .DateInput {
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: .125rem .75rem;
+  border-radius: .25rem;
+  font-weight: 200;
+}
+
+.dbc-datepicker.dbc-datepicker-sm .SingleDatePickerInput, .dbc-datepicker.dbc-datepicker-sm .DateRangePickerInput {
   height: calc(1.8125rem + 2px);
   font-size: .875rem;
   line-height: 1.5;
   border-radius: .2rem;
 }
 
-.date-picker-sm .DateInput {
+.dbc-datepicker.dbc-datepicker-sm .DateInput {
   font-size: .875rem;
   line-height: 1.5;
   padding: 0 .5rem;
   width: 110px;
 }
 
-.date-picker-lg .SingleDatePickerInput {
+.dbc-datepicker.dbc-datepicker-lg .SingleDatePickerInput, .dbc-datepicker.dbc-datepicker-lg .DateRangePickerInput {
   height: calc(2.875rem + 2px);
   font-size: 1.25rem;
   line-height: 1.5;
   border-radius: .3rem;
 }
 
-.date-picker-lg .DateInput {
+.dbc-datepicker.dbc-datepicker-lg .DateInput {
   font-size: 1.25rem;
   line-height: 1.5;
   padding: .25rem 1rem;
@@ -615,13 +646,12 @@
 }
 
 .DateInput {
-  font-size: 1rem;
-  line-height: 1.5;
-  padding: .125rem .75rem;
-  border-radius: .25rem;
   font-weight: 200;
+  font-size: 18px;
+  line-height: 24px;
   color: #757575;
   margin: 0;
+  padding: 8px;
   background: #fff;
   position: relative;
   display: inline-block;
@@ -911,16 +941,8 @@
 }
 
 .SingleDatePickerInput {
-  border: 1px solid #ced4da;
   background-color: #fff;
-  border-radius: .25rem;
-  height: calc(2.25rem + 2px);
-  font-size: 1rem;
-  line-height: 1.5;
-  color: #495057;
-  background-clip: padding-box;
-  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
-  /* background-color: #fff;border: 1px solid #dbdbdb; */
+  border: 1px solid #dbdbdb;
 }
 
 .SingleDatePickerInput--rtl {

--- a/src/components/input/react-dates@12.3.0.css
+++ b/src/components/input/react-dates@12.3.0.css
@@ -1,3 +1,7 @@
+.form-group > .SingleDatePicker, .form-group > .DateRangePicker {
+  display: table;
+}
+
 .CalendarDay {
   border: 1px solid #e4e7e7;
   padding: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export {default as Checklist} from './components/input/Checklist';
 export {default as Col} from './components/layout/Col';
 export {default as Collapse} from './components/Collapse';
 export {default as Container} from './components/layout/Container';
+export {default as DatePickerSingle} from './components/input/DatePickerSingle';
 export {default as DropdownMenu} from './components/DropdownMenu';
 export {default as DropdownMenuItem} from './components/DropdownMenuItem';
 export {default as Fade} from './components/Fade';

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export {default as Checklist} from './components/input/Checklist';
 export {default as Col} from './components/layout/Col';
 export {default as Collapse} from './components/Collapse';
 export {default as Container} from './components/layout/Container';
+export {default as DatePickerRange} from './components/input/DatePickerRange';
 export {default as DatePickerSingle} from './components/input/DatePickerSingle';
 export {default as DropdownMenu} from './components/DropdownMenu';
 export {default as DropdownMenuItem} from './components/DropdownMenuItem';


### PR DESCRIPTION
This PR adds `DatePickerSingle` `DatePickerRange` components which which shadow the implementations in Dash core components, but with the styles modified to fit with bootstrap components.

In addition to this it adds a `bs_size` prop which allows you to control the size of the components in the same way that bootstrap allows you to size form controls, see [here](https://getbootstrap.com/docs/4.1/components/forms/#sizing)

This closes issue #21. You can see it working in `examples/date_picker.py`.

Here's a screenshot of the different sizes in action

![image](https://user-images.githubusercontent.com/15220906/48099722-636d4c80-e218-11e8-90ca-3bd80d08706c.png)
