### PR TITLE
Configure isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
 exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py, docs/components_page/components/popover.py
 ignore = E203, W503
+
+[isort]
+multi_line_output=3
+include_trailing_comma=true


### PR DESCRIPTION
This small PR configures the python package `isort` to work with `black`. Previously `isort` and `black` would clash when multiple functions were imported from a module.