### PR TITLE
Fix outdated demo and verify demo builds in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 script:
   - "if [[ \"$GROUP\" == js ]] ; then npm run lint ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm run test ; fi"
+  - "if [[ \"$GROUP\" == js ]] ; then npm run test:demo ; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then black . --check ; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then flake8 ; fi"
   - "if [[ \"$GROUP\" == python-test ]] ; then python -m compileall dash_bootstrap_components ; fi"

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -133,11 +133,11 @@ class Demo extends Component {
           <NavLink href="https://www.asidatascience.com">A link</NavLink>
         </NavItem>
         <DropdownMenu nav in_navbar label="Menu">
-          <DropdownItem>Entry 1</DropdownItem>
-          <DropdownItem>Entry 2</DropdownItem>
-          <DropdownItem divider />
-          <DropdownItem>Entry 3</DropdownItem>
-        </Dropdown>
+          <DropdownMenuItem>Entry 1</DropdownMenuItem>
+          <DropdownMenuItem>Entry 2</DropdownMenuItem>
+          <DropdownMenuItem divider />
+          <DropdownMenuItem>Entry 3</DropdownMenuItem>
+        </DropdownMenu>
       </Navbar>
       <Container>
         <h1>Dash Bootstrap Components</h1>
@@ -365,14 +365,14 @@ class Demo extends Component {
 
       <br/>
 
-      <h2>Dropdown</h2>
-      <Dropdown label="Toggle" caret={true}>
-        <DropdownItem header={true}>Heading</DropdownItem>
-        <DropdownItem>An item</DropdownItem>
-        <DropdownItem divider={true}/>
-        <DropdownItem header={true}>Another heading</DropdownItem>
-        <DropdownItem>Another item</DropdownItem>
-      </Dropdown>
+      <h2>DropdownMenu</h2>
+      <DropdownMenu label="Toggle" caret={true}>
+        <DropdownMenuItem header={true}>Heading</DropdownMenuItem>
+        <DropdownMenuItem>An item</DropdownMenuItem>
+        <DropdownMenuItem divider={true}/>
+        <DropdownMenuItem header={true}>Another heading</DropdownMenuItem>
+        <DropdownMenuItem>Another item</DropdownMenuItem>
+      </DropdownMenu>
 
       <br/>
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "prettier src/**/*.js --list-different",
     "prepublish": "NODE_ENV=production npm run build-dist && npm run copy-lib",
     "test": "jest",
+    "test:demo": "webpack --content-base=demo --config=webpack.config.demo.js",
     "test:watch": "jest --watch"
   },
   "author": "ASI Data Science",


### PR DESCRIPTION
The JS demo was broken because it still used `<Dropdown />` instead of `<DropdownMenu />`. This fixes the demo and adds a basic check that the demo builds to the CI pipeline to avoid regressions.