### PR TITLE
Fix hot reloading when demo runs behind a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-dist": "npm run clean-lib && npm run extract-metadata && webpack --config=webpack.config.dist.js",
     "clean-lib": "mkdirp lib && rimraf lib/*",
     "copy-lib": "copyfiles -u 1 lib/* dash_bootstrap_components",
-    "demo": "webpack-dev-server --hot --inline --port=8888 --disable-host-check --content-base demo --config=webpack.config.demo.js",
+    "demo": "webpack-dev-server --hot --inline --port=8888 --content-base=demo --config=webpack.config.demo.js",
     "extract-metadata": "mkdirp lib && react-docgen --pretty -o lib/metadata.json src/components && node -e \"const fs = require('fs'); const path = require('path'); const m = JSON.parse(fs.readFileSync('./lib/metadata.json')); const r = {}; Object.keys(m).forEach(k => r[k.split(path.sep).join('/')] = m[k]); fs.writeFileSync('./lib/metadata.json', JSON.stringify(r, '\t', 2));\"",
     "format": "prettier src/**/*.js --write",
     "lint": "prettier src/**/*.js --list-different",

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -13,8 +13,11 @@ var environment = JSON.stringify(NODE_ENV);
 var LIBRARY_NAME = 'dash_bootstrap_components';
 var BUILD_PATH = path.join(ROOT, 'lib');
 
+var publicHost = process.env.DEMO_PUBLIC_HOST || undefined;
+
 /* eslint-disable no-console */
 console.log('Current environment: ' + environment);
+console.log('Using public host: ' + publicHost || '<default>');
 /* eslint-enable no-console */
 
 module.exports = {
@@ -56,6 +59,9 @@ module.exports = {
   ],
   entry: {
     bundle: [path.join(ROOT, 'demo/index.js')]
+  },
+  devServer: {
+    public: publicHost,
   },
   output: {
     library: LIBRARY_NAME,


### PR DESCRIPTION
Prior to this PR, `npm run demo` created an app where hot-reloading did not work if the app was behind a proxy, because the browser client looked for the backend at localhost, rather than using window.location. To work at all, we disabled the host check, which, in principle, opened the backend to phishing attacks [1].

Now, we allow configuring the host header for the frontend using the DEMO_PUBLIC_HOST environment variable [2]. If that variable is set, it will be used by the frontend and by the host check in the backend. If not, we fall back to the webpack default (localhost:<port>, in most occasions).

[1] These would not work on SherlockML because we have an additional layer of security that verifies the host header.

[2] To make this work on SherlockML, write the following in your shell:

```
export SHERLOCKML_PUBLIC_HOST=cube-"$SHERLOCKML_SERVER_ID".workspace.asi.sherlockml.net
```

Builds on PR #48.