### PR TITLE
Document input group

### DIFF
--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -1,5 +1,7 @@
+
 import dash_html_components as html
 import dash_bootstrap_components as dbc
+from dash.dependencies import Input, Output
 
 input_group = html.Div(
     [
@@ -9,12 +11,25 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon(
-                            dbc.Button("Button text"), addon_type="prepend"
+                            dbc.Button("Random name", id="input-group-button"),
+                            addon_type="prepend"
                         ),
-                        dbc.Input(),
+                        dbc.Input(id="input-group-button-input", placeholder="name"),
                     ]
                 )
             ]
         ),
     ]
 )
+
+@app.callback(
+    Output("input-group-button-input", "value"),
+    [Input("input-group-button", "n_clicks")]
+)
+def on_button_click(n_clicks):
+    if n_clicks:
+        names = ["Arthur Dent", "Ford Prefect", "Trillian Astra"]
+        which = n_clicks % len(names)
+        return names[which]
+    else:
+        return ""

--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -1,5 +1,5 @@
-import dash_html_components as html
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 from dash.dependencies import Input, Output
 
 input_group = html.Div(

--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -11,9 +11,11 @@ input_group = html.Div(
                     [
                         dbc.InputGroupAddon(
                             dbc.Button("Random name", id="input-group-button"),
-                            addon_type="prepend"
+                            addon_type="prepend",
                         ),
-                        dbc.Input(id="input-group-button-input", placeholder="name"),
+                        dbc.Input(
+                            id="input-group-button-input", placeholder="name"
+                        ),
                     ]
                 )
             ]
@@ -21,9 +23,10 @@ input_group = html.Div(
     ]
 )
 
+
 @app.callback(
     Output("input-group-button-input", "value"),
-    [Input("input-group-button", "n_clicks")]
+    [Input("input-group-button", "n_clicks")],
 )
 def on_button_click(n_clicks):
     if n_clicks:

--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -1,11 +1,10 @@
-
 import dash_html_components as html
 import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output
 
 input_group = html.Div(
     [
-        html.H4("Buttons"),
+        html.H4("Button"),
         html.Div(
             [
                 dbc.InputGroup(

--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -1,0 +1,21 @@
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+
+input_group = html.Div(
+    [
+        html.H4("Buttons"),
+        html.Div(
+            [
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon(
+                            dbc.Button("Button text"),
+                            addon_type="prepend"
+                        ),
+                        dbc.Input()
+                    ]
+                )
+            ]
+        )
+    ]
+)

--- a/docs/components_page/components/input_group/button.py
+++ b/docs/components_page/components/input_group/button.py
@@ -9,13 +9,12 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon(
-                            dbc.Button("Button text"),
-                            addon_type="prepend"
+                            dbc.Button("Button text"), addon_type="prepend"
                         ),
-                        dbc.Input()
+                        dbc.Input(),
                     ]
                 )
             ]
-        )
+        ),
     ]
 )

--- a/docs/components_page/components/input_group/dropdown.py
+++ b/docs/components_page/components/input_group/dropdown.py
@@ -1,0 +1,52 @@
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+from dash.dependencies import Input, Output
+
+input_group = html.Div(
+    [
+        html.H4("DropdownMenu"),
+        html.Div(
+            [
+                dbc.InputGroup(
+                    [
+                        dbc.DropdownMenu(
+                            [
+                                dbc.DropdownMenuItem("Deep thought", id="dropdown-menu-item-1"),
+                                dbc.DropdownMenuItem("Hal", id="dropdown-menu-item-2"),
+                                dbc.DropdownMenuItem(divider=True),
+                                dbc.DropdownMenuItem("Clear", id="dropdown-menu-item-clear"),
+                            ],
+                            label="Generate",
+                            addon_type="prepend"
+                        ),
+                        dbc.Input(id="input-group-dropdown-input", placeholder="name"),
+                    ]
+                )
+            ]
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("input-group-dropdown-input", "value"),
+    [Input("dropdown-menu-item-1", "n_clicks_timestamp"), Input("dropdown-menu-item-2", "n_clicks_timestamp"), Input("dropdown-menu-item-clear", "n_clicks_timestamp")]
+)
+def on_button_click(n_clicks_t1, n_clicks_t2, n_clicks_tclear):
+    if n_clicks_t1 is None and n_clicks_t2 is None:
+        return ""
+    n_clicks_t1 = n_clicks_t1 if n_clicks_t1 is not None else -1
+    n_clicks_t2 = n_clicks_t2 if n_clicks_t2 is not None else -1
+    n_clicks_tclear = n_clicks_tclear if n_clicks_tclear is not None else -1
+    latest_timestamp = max(n_clicks_tclear, n_clicks_t1, n_clicks_t2)
+    print(latest_timestamp)
+    if latest_timestamp == n_clicks_tclear:
+        return ""
+    elif latest_timestamp == n_clicks_t1:
+        names = ["Arthur Dent", "Ford Prefect", "Trillian Astra"]
+        which = n_clicks_t1 % len(names)
+        return names[which]
+    else:
+        names = ["David Bowman", "Frank Poole", "Dr. Heywood Floyd"]
+        which = n_clicks_t2 % len(names)
+        return names[which]

--- a/docs/components_page/components/input_group/dropdown.py
+++ b/docs/components_page/components/input_group/dropdown.py
@@ -1,7 +1,6 @@
-import dash_html_components as html
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 from dash.dependencies import Input, Output
-
 
 dropdown_menu_items = [
     dbc.DropdownMenuItem("Deep thought", id="dropdown-menu-item-1"),

--- a/docs/components_page/components/input_group/dropdown.py
+++ b/docs/components_page/components/input_group/dropdown.py
@@ -2,6 +2,15 @@ import dash_html_components as html
 import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output
 
+
+dropdown_menu_items = [
+    dbc.DropdownMenuItem("Deep thought", id="dropdown-menu-item-1"),
+    dbc.DropdownMenuItem("Hal", id="dropdown-menu-item-2"),
+    dbc.DropdownMenuItem(divider=True),
+    dbc.DropdownMenuItem("Clear", id="dropdown-menu-item-clear"),
+]
+
+
 input_group = html.Div(
     [
         html.H4("DropdownMenu"),
@@ -10,16 +19,13 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.DropdownMenu(
-                            [
-                                dbc.DropdownMenuItem("Deep thought", id="dropdown-menu-item-1"),
-                                dbc.DropdownMenuItem("Hal", id="dropdown-menu-item-2"),
-                                dbc.DropdownMenuItem(divider=True),
-                                dbc.DropdownMenuItem("Clear", id="dropdown-menu-item-clear"),
-                            ],
+                            dropdown_menu_items,
                             label="Generate",
-                            addon_type="prepend"
+                            addon_type="prepend",
                         ),
-                        dbc.Input(id="input-group-dropdown-input", placeholder="name"),
+                        dbc.Input(
+                            id="input-group-dropdown-input", placeholder="name"
+                        ),
                     ]
                 )
             ]
@@ -30,7 +36,11 @@ input_group = html.Div(
 
 @app.callback(
     Output("input-group-dropdown-input", "value"),
-    [Input("dropdown-menu-item-1", "n_clicks_timestamp"), Input("dropdown-menu-item-2", "n_clicks_timestamp"), Input("dropdown-menu-item-clear", "n_clicks_timestamp")]
+    [
+        Input("dropdown-menu-item-1", "n_clicks_timestamp"),
+        Input("dropdown-menu-item-2", "n_clicks_timestamp"),
+        Input("dropdown-menu-item-clear", "n_clicks_timestamp"),
+    ],
 )
 def on_button_click(n_clicks_t1, n_clicks_t2, n_clicks_tclear):
     if n_clicks_t1 is None and n_clicks_t2 is None:

--- a/docs/components_page/components/input_group/simple.py
+++ b/docs/components_page/components/input_group/simple.py
@@ -9,9 +9,17 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon("@", addon_type="prepend"),
-                        dbc.Input(placeholder="username")
+                        dbc.Input(placeholder="username"),
+                    ]
+                ),
+                html.Br(),
+                dbc.InputGroup(
+                    [
+                        dbc.Input(placeholder="username"),
+                        dbc.InputGroupAddon("@example.com", addon_type="append"),
                     ]
                 )
+
             ]
         )
     ]

--- a/docs/components_page/components/input_group/simple.py
+++ b/docs/components_page/components/input_group/simple.py
@@ -16,7 +16,9 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.Input(placeholder="username"),
-                        dbc.InputGroupAddon("@example.com", addon_type="append"),
+                        dbc.InputGroupAddon(
+                            "@example.com", addon_type="append"
+                        ),
                     ]
                 ),
                 html.Br(),
@@ -24,10 +26,10 @@ input_group = html.Div(
                     [
                         dbc.InputGroupAddon("$", addon_type="prepend"),
                         dbc.Input(placeholder="Amount", type="number"),
-                        dbc.InputGroupAddon(".00", addon_type="append")
+                        dbc.InputGroupAddon(".00", addon_type="append"),
                     ]
-                )
+                ),
             ]
-        )
+        ),
     ]
 )

--- a/docs/components_page/components/input_group/simple.py
+++ b/docs/components_page/components/input_group/simple.py
@@ -18,8 +18,15 @@ input_group = html.Div(
                         dbc.Input(placeholder="username"),
                         dbc.InputGroupAddon("@example.com", addon_type="append"),
                     ]
+                ),
+                html.Br(),
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon("$", addon_type="prepend"),
+                        dbc.Input(placeholder="Amount", type="number"),
+                        dbc.InputGroupAddon(".00", addon_type="append")
+                    ]
                 )
-
             ]
         )
     ]

--- a/docs/components_page/components/input_group/simple.py
+++ b/docs/components_page/components/input_group/simple.py
@@ -1,0 +1,18 @@
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+
+input_group = html.Div(
+    [
+        html.H2("Input group"),
+        html.Div(
+            [
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon("@", addon_type="prepend"),
+                        dbc.Input(placeholder="username")
+                    ]
+                )
+            ]
+        )
+    ]
+)

--- a/docs/components_page/components/input_group/simple.py
+++ b/docs/components_page/components/input_group/simple.py
@@ -1,5 +1,5 @@
-import dash_html_components as html
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 
 input_group = html.Div(
     [

--- a/docs/components_page/components/input_group/size.py
+++ b/docs/components_page/components/input_group/size.py
@@ -1,0 +1,34 @@
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+
+input_group = html.Div(
+    [
+        html.H4("Addon sizing"),
+        html.Div(
+            [
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon("@lg", addon_type="prepend"),
+                        dbc.Input()
+                    ],
+                    size="lg"
+                ),
+                html.Br(),
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon("@normal", addon_type="prepend"),
+                        dbc.Input()
+                    ]
+                ),
+                html.Br(),
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupAddon("@sm", addon_type="prepend"),
+                        dbc.Input()
+                    ],
+                    size="sm"
+                ),
+            ]
+        )
+    ]
+)

--- a/docs/components_page/components/input_group/size.py
+++ b/docs/components_page/components/input_group/size.py
@@ -9,26 +9,26 @@ input_group = html.Div(
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon("@lg", addon_type="prepend"),
-                        dbc.Input()
+                        dbc.Input(),
                     ],
-                    size="lg"
+                    size="lg",
                 ),
                 html.Br(),
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon("@normal", addon_type="prepend"),
-                        dbc.Input()
+                        dbc.Input(),
                     ]
                 ),
                 html.Br(),
                 dbc.InputGroup(
                     [
                         dbc.InputGroupAddon("@sm", addon_type="prepend"),
-                        dbc.Input()
+                        dbc.Input(),
                     ],
-                    size="sm"
+                    size="sm",
                 ),
             ]
-        )
+        ),
     ]
 )

--- a/docs/components_page/components/input_group/size.py
+++ b/docs/components_page/components/input_group/size.py
@@ -1,5 +1,5 @@
-import dash_html_components as html
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 
 input_group = html.Div(
     [

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -24,14 +24,14 @@ content = [
     HighlightedSource(input_group_button_source),
     ApiDoc(
         get_component_metadata("src/components/input/InputGroup.js"),
-        component_name="InputGroup"
+        component_name="InputGroup",
     ),
     ApiDoc(
         get_component_metadata("src/components/input/InputGroupAddon.js"),
-        component_name="InputGroupAddon"
+        component_name="InputGroupAddon",
     ),
     ApiDoc(
         get_component_metadata("src/components/input/InputGroupText.js"),
-        component_name="InputGroupText"
+        component_name="InputGroupText",
     ),
 ]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -6,16 +6,20 @@ from .metadata import get_component_metadata
 
 from .components.input_group.simple import input_group as input_group_simple
 from .components.input_group.size import input_group as input_group_size
+from .components.input_group.button import input_group as input_group_button
 
 HERE = Path(__file__).parent
 INPUT_GROUP = HERE / "components" / "input_group"
 
 input_group_simple_source = (INPUT_GROUP / "simple.py").open().read()
 input_group_size_source = (INPUT_GROUP / "size.py").open().read()
+input_group_button_source = (INPUT_GROUP / "button.py").open().read()
 
 content = [
     ExampleContainer(input_group_simple),
     HighlightedSource(input_group_simple_source),
     ExampleContainer(input_group_size),
-    HighlightedSource(input_group_size_source)
+    HighlightedSource(input_group_size_source),
+    ExampleContainer(input_group_button),
+    HighlightedSource(input_group_button_source)
 ]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from .helpers import ExampleContainer, HighlightedSource
+from .api_doc import ApiDoc
+from .metadata import get_component_metadata
+
+from .components.input_group.simple import input_group as input_group_simple
+
+HERE = Path(__file__).parent
+INPUT_GROUP = HERE / "components" / "input_group"
+
+input_group_simple_source = (INPUT_GROUP / "simple.py").open().read()
+
+content = [
+    ExampleContainer(input_group_simple),
+    HighlightedSource(input_group_simple_source)
+]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
-from .helpers import ExampleContainer, HighlightedSource
+from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
 from .metadata import get_component_metadata
 
 from .components.input_group.simple import input_group as input_group_simple
 from .components.input_group.size import input_group as input_group_size
-from .components.input_group.button import input_group as input_group_button
 
 HERE = Path(__file__).parent
 INPUT_GROUP = HERE / "components" / "input_group"
@@ -15,23 +14,25 @@ input_group_simple_source = (INPUT_GROUP / "simple.py").open().read()
 input_group_size_source = (INPUT_GROUP / "size.py").open().read()
 input_group_button_source = (INPUT_GROUP / "button.py").open().read()
 
-content = [
-    ExampleContainer(input_group_simple),
-    HighlightedSource(input_group_simple_source),
-    ExampleContainer(input_group_size),
-    HighlightedSource(input_group_size_source),
-    ExampleContainer(input_group_button),
-    HighlightedSource(input_group_button_source),
-    ApiDoc(
-        get_component_metadata("src/components/input/InputGroup.js"),
-        component_name="InputGroup",
-    ),
-    ApiDoc(
-        get_component_metadata("src/components/input/InputGroupAddon.js"),
-        component_name="InputGroupAddon",
-    ),
-    ApiDoc(
-        get_component_metadata("src/components/input/InputGroupText.js"),
-        component_name="InputGroupText",
-    ),
-]
+
+def get_content(app):
+    return [
+        ExampleContainer(input_group_simple),
+        HighlightedSource(input_group_simple_source),
+        ExampleContainer(input_group_size),
+        HighlightedSource(input_group_size_source),
+        ExampleContainer(load_source_with_app(app, input_group_button_source, "input_group")),
+        HighlightedSource(input_group_button_source),
+        ApiDoc(
+            get_component_metadata("src/components/input/InputGroup.js"),
+            component_name="InputGroup",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/input/InputGroupAddon.js"),
+            component_name="InputGroupAddon",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/input/InputGroupText.js"),
+            component_name="InputGroupText",
+        ),
+    ]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -27,10 +27,6 @@ content = [
         component_name="InputGroup"
     ),
     ApiDoc(
-        get_component_metadata("src/components/input/Input.js"),
-        component_name="Input"
-    ),
-    ApiDoc(
         get_component_metadata("src/components/input/InputGroupAddon.js"),
         component_name="InputGroupAddon"
     ),

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
-from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
 from .api_doc import ApiDoc
-from .metadata import get_component_metadata
-
 from .components.input_group.simple import input_group as input_group_simple
 from .components.input_group.size import input_group as input_group_size
+from .helpers import ExampleContainer, HighlightedSource, load_source_with_app
+from .metadata import get_component_metadata
 
 HERE = Path(__file__).parent
 INPUT_GROUP = HERE / "components" / "input_group"

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -5,13 +5,17 @@ from .api_doc import ApiDoc
 from .metadata import get_component_metadata
 
 from .components.input_group.simple import input_group as input_group_simple
+from .components.input_group.size import input_group as input_group_size
 
 HERE = Path(__file__).parent
 INPUT_GROUP = HERE / "components" / "input_group"
 
 input_group_simple_source = (INPUT_GROUP / "simple.py").open().read()
+input_group_size_source = (INPUT_GROUP / "size.py").open().read()
 
 content = [
     ExampleContainer(input_group_simple),
-    HighlightedSource(input_group_simple_source)
+    HighlightedSource(input_group_simple_source),
+    ExampleContainer(input_group_size),
+    HighlightedSource(input_group_size_source)
 ]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -22,9 +22,15 @@ def get_content(app):
         HighlightedSource(input_group_simple_source),
         ExampleContainer(input_group_size),
         HighlightedSource(input_group_size_source),
-        ExampleContainer(load_source_with_app(app, input_group_button_source, "input_group")),
+        ExampleContainer(
+            load_source_with_app(app, input_group_button_source, "input_group")
+        ),
         HighlightedSource(input_group_button_source),
-        ExampleContainer(load_source_with_app(app, input_group_dropdown_source, "input_group")),
+        ExampleContainer(
+            load_source_with_app(
+                app, input_group_dropdown_source, "input_group"
+            )
+        ),
         HighlightedSource(input_group_dropdown_source),
         ApiDoc(
             get_component_metadata("src/components/input/InputGroup.js"),

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -21,5 +21,21 @@ content = [
     ExampleContainer(input_group_size),
     HighlightedSource(input_group_size_source),
     ExampleContainer(input_group_button),
-    HighlightedSource(input_group_button_source)
+    HighlightedSource(input_group_button_source),
+    ApiDoc(
+        get_component_metadata("src/components/input/InputGroup.js"),
+        component_name="InputGroup"
+    ),
+    ApiDoc(
+        get_component_metadata("src/components/input/Input.js"),
+        component_name="Input"
+    ),
+    ApiDoc(
+        get_component_metadata("src/components/input/InputGroupAddon.js"),
+        component_name="InputGroupAddon"
+    ),
+    ApiDoc(
+        get_component_metadata("src/components/input/InputGroupText.js"),
+        component_name="InputGroupText"
+    ),
 ]

--- a/docs/components_page/input_group_content.py
+++ b/docs/components_page/input_group_content.py
@@ -13,6 +13,7 @@ INPUT_GROUP = HERE / "components" / "input_group"
 input_group_simple_source = (INPUT_GROUP / "simple.py").open().read()
 input_group_size_source = (INPUT_GROUP / "size.py").open().read()
 input_group_button_source = (INPUT_GROUP / "button.py").open().read()
+input_group_dropdown_source = (INPUT_GROUP / "dropdown.py").open().read()
 
 
 def get_content(app):
@@ -23,6 +24,8 @@ def get_content(app):
         HighlightedSource(input_group_size_source),
         ExampleContainer(load_source_with_app(app, input_group_button_source, "input_group")),
         HighlightedSource(input_group_button_source),
+        ExampleContainer(load_source_with_app(app, input_group_dropdown_source, "input_group")),
+        HighlightedSource(input_group_dropdown_source),
         ApiDoc(
             get_component_metadata("src/components/input/InputGroup.js"),
             component_name="InputGroup",

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -9,6 +9,7 @@ from .cards_content import content as cards_content
 from .collapse_content import get_content as get_collapse_content
 from .fade_content import get_content as get_fade_content
 from .forms_content import content as forms_content
+from .input_group_content import content as input_group_content
 from .layout_content import content as layout_content
 from .popover_content import get_content as get_popover_content
 from .progress_content import get_content as get_progress_content
@@ -37,6 +38,7 @@ sidebar_entries = [
     SidebarEntry("collapse", "Collapse"),
     SidebarEntry("fade", "Fade"),
     SidebarEntry("forms", "Forms"),
+    SidebarEntry("input_group", "Input Group"),
     SidebarEntry("layout", "Layout"),
     SidebarEntry("popover", "Popover"),
     SidebarEntry("progress", "Progress"),
@@ -65,6 +67,7 @@ class ComponentsPage:
             "collapse": get_collapse_content(self._app),
             "fade": get_fade_content(self._app),
             "forms": forms_content,
+            "input_group": input_group_content,
             "layout": layout_content,
             "popover": get_popover_content(self._app),
             "progress": get_progress_content(self._app),

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -9,7 +9,7 @@ from .cards_content import content as cards_content
 from .collapse_content import get_content as get_collapse_content
 from .fade_content import get_content as get_fade_content
 from .forms_content import content as forms_content
-from .input_group_content import content as input_group_content
+from .input_group_content import get_content as get_input_group_content
 from .layout_content import content as layout_content
 from .popover_content import get_content as get_popover_content
 from .progress_content import get_content as get_progress_content
@@ -67,7 +67,7 @@ class ComponentsPage:
             "collapse": get_collapse_content(self._app),
             "fade": get_fade_content(self._app),
             "forms": forms_content,
-            "input_group": input_group_content,
+            "input_group": get_input_group_content(self._app),
             "layout": layout_content,
             "popover": get_popover_content(self._app),
             "progress": get_progress_content(self._app),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,25 @@
 [flake8]
-exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py, docs/components_page/components/popover.py, docs/components_page/components/fade.py, docs/components_page/components/input_group/button.py, docs/components_page/components/input_group/dropdown.py, docs/components_page/components/progress.py
+exclude =
+    node_modules,
+    docs/components_page/components/collapse.py,
+    docs/components_page/components/buttons/usage.py,
+    docs/components_page/components/popover.py,
+    docs/components_page/components/fade.py,
+    docs/components_page/components/input_group/button.py,
+    docs/components_page/components/input_group/dropdown.py,
+    docs/components_page/components/progress.py
 ignore = E203, W503
 
 [isort]
 multi_line_output = 3
 include_trailing_comma = true
-known_third_party = dash, dash_bootstrap_components, dash_core_components, dash_html_components, flask, invoke, semver, setuptools, termcolor
+known_third_party =
+    dash,
+    dash_bootstrap_components,
+    dash_core_components,
+    dash_html_components,
+    flask,
+    invoke,
+    semver,
+    setuptools,
+    termcolor

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py, docs/components_page/components/popover.py, docs/components_page/components/fade.py, docs/components_page/components/progress.py
+exclude = node_modules, docs/components_page/components/collapse.py, docs/components_page/components/buttons/usage.py, docs/components_page/components/popover.py, docs/components_page/components/fade.py, docs/components_page/components/input_group/button.py, docs/components_page/components/input_group/dropdown.py, docs/components_page/components/progress.py
 ignore = E203, W503
 
 [isort]

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -15,7 +15,7 @@ InputGroup.propTypes = {
   id: PropTypes.string,
 
   /**
-   * The children of this component
+   * The children of this component.
    */
   children: PropTypes.node,
 

--- a/src/components/input/InputGroupAddon.js
+++ b/src/components/input/InputGroupAddon.js
@@ -30,7 +30,7 @@ InputGroupAddon.propTypes = {
   id: PropTypes.string,
 
   /**
-   * The children of this component
+   * The children of this component.
    */
   children: PropTypes.node,
 

--- a/src/components/input/InputGroupText.js
+++ b/src/components/input/InputGroupText.js
@@ -15,7 +15,7 @@ InputGroupText.propTypes = {
   id: PropTypes.string,
 
   /**
-   * The children of this component
+   * The children of this component.
    */
   children: PropTypes.node,
 


### PR DESCRIPTION
This adds documentation for input groups. I'd originally planned to document `dbc.Input` as part of this, but realised that that was probably sufficiently large to warrant its own separate documentation.

This is rebased on top of #59.

I can't deploy this very easily since it requires building the bundle, but this is what the documentation looks like:

![dbc-input-group-screenshot](https://user-images.githubusercontent.com/1392879/48660205-f21e6c80-ea55-11e8-9835-7e937c4e6346.png)

