### PR TITLE
Add `addon_type` prop to `DropdownMenu`

### DIFF
--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -50,7 +50,8 @@ class DropdownMenu extends React.Component {
 }
 
 DropdownMenu.defaultProps = {
-  caret: true
+  caret: true,
+  disabled: false
 };
 
 DropdownMenu.propTypes = {

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -97,7 +97,10 @@ DropdownMenu.propTypes = {
   /**
    * Set this to 'prepend' or 'append' if the dropdown menu is being used in an input group.
    */
-  addon_type: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['prepend', 'append'])]),
+  addon_type: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf(['prepend', 'append'])
+  ]),
 
   /**
    * Disable the dropdown.

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -29,6 +29,7 @@ class DropdownMenu extends React.Component {
       disabled,
       caret,
       in_navbar,
+      addon_type,
       ...otherProps
     } = this.props;
     return (
@@ -38,6 +39,7 @@ class DropdownMenu extends React.Component {
         nav={nav}
         disabled={disabled}
         inNavbar={in_navbar}
+        addonType={addon_type}
         {...otherProps}
       >
         <DropdownToggle nav={nav} caret={caret} disabled={disabled}>
@@ -91,6 +93,11 @@ DropdownMenu.propTypes = {
    * For Dropdown usage inside a Navbar (disables popper)
    */
   in_navbar: PropTypes.bool,
+
+  /**
+   * Set this to 'prepend' or 'append' if the dropdown menu is being used in an input group.
+   */
+  addon_type: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['prepend', 'append'])]),
 
   /**
    * Disable the dropdown.

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -106,7 +106,7 @@ describe('DropdownMenu - options', () => {
 
   it('multiple items', () => {
     dropdownMenu = shallow(
-      <DropdownMenu label="Label" nav={true}>
+      <DropdownMenu label="Label">
         <DropdownMenuItem>Item 1</DropdownMenuItem>
         <DropdownMenuItem>Item 2</DropdownMenuItem>
         <DropdownMenuItem>Item 3</DropdownMenuItem>
@@ -118,6 +118,50 @@ describe('DropdownMenu - options', () => {
     expect(rsDropdownMenu.childAt(0).prop('children')).toEqual('Item 1')
     expect(rsDropdownMenu.childAt(1).prop('children')).toEqual('Item 2')
     expect(rsDropdownMenu.childAt(2).prop('children')).toEqual('Item 3')
+  })
+
+  it('addon_type -- undefined', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label">
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('addonType')).toBeFalsy()
+  })
+
+  it('addon_type -- true', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" addon_type={true}>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('addonType')).toBe(true)
+  })
+
+  it('addon_type -- prepend', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" addon_type="prepend">
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('addonType')).toEqual('prepend')
+  })
+
+  it('addon_type -- append', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" addon_type="append">
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('addonType')).toEqual('append')
   })
 
   afterEach(() => {

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {
   Dropdown as RSDropdown,
   DropdownToggle as RSDropdownToggle,
@@ -45,4 +45,11 @@ describe('Simple DropdownMenu', () => {
     expect(dropdownMenuChildren).toHaveLength(1)
     expect(dropdownMenuChildren.prop('children')).toEqual('Item 1')
   })
+
+  it('should open when the `toggle` callback is called', () => {
+    expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(false)
+    rsDropdown.prop('toggle')();
+    expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(true)
+  })
+
 })

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -16,7 +16,7 @@ describe('Simple DropdownMenu', () => {
 
   beforeAll(() => {
     dropdownMenu = shallow(
-      <DropdownMenu>
+      <DropdownMenu label="Label">
         <DropdownMenuItem>Item 1</DropdownMenuItem>
       </DropdownMenu>
     )
@@ -33,4 +33,16 @@ describe('Simple DropdownMenu', () => {
 
   it('should create a reactstrap dropdown menu', () =>
     expect(rsDropdownMenu).toHaveLength(1));
+
+  it('should set the caret option in the toggle', () =>
+    expect(rsDropdownToggle.prop('caret')).toBe(true))
+
+  it('should pass the label onto the toggle', () =>
+    expect(rsDropdownToggle.prop('children')).toEqual('Label'))
+
+  it('should pass its own children onto the reactstrap dropdown menu', () => {
+    const dropdownMenuChildren = rsDropdownMenu.find(DropdownMenuItem)
+    expect(dropdownMenuChildren).toHaveLength(1)
+    expect(dropdownMenuChildren.prop('children')).toEqual('Item 1')
+  })
 })

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -104,6 +104,22 @@ describe('DropdownMenu - options', () => {
     expect(rsDropdownToggle.prop('nav')).toBe(true)
   })
 
+  it('multiple items', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" nav={true}>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+        <DropdownMenuItem>Item 2</DropdownMenuItem>
+        <DropdownMenuItem>Item 3</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdownMenu = dropdownMenu.find(RSDropdownMenu);
+
+    expect(rsDropdownMenu.children()).toHaveLength(3)
+    expect(rsDropdownMenu.childAt(0).prop('children')).toEqual('Item 1')
+    expect(rsDropdownMenu.childAt(1).prop('children')).toEqual('Item 2')
+    expect(rsDropdownMenu.childAt(2).prop('children')).toEqual('Item 3')
+  })
+
   afterEach(() => {
     dropdownMenu.unmount();
   })

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -46,10 +46,12 @@ describe('Simple DropdownMenu', () => {
     expect(dropdownMenuChildren.prop('children')).toEqual('Item 1')
   })
 
-  it('should open when the `toggle` callback is called', () => {
+  it('should open and close when the `toggle` callback is called', () => {
     expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(false)
     rsDropdown.prop('toggle')();
     expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(true)
+    rsDropdown.prop('toggle')();
+    expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(false)
   })
 
 })

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {
+  Dropdown as RSDropdown,
+  DropdownToggle as RSDropdownToggle,
+  DropdownMenu as RSDropdownMenu
+} from 'reactstrap';
+import DropdownMenu from '../DropdownMenu';
+import DropdownMenuItem from '../DropdownMenuItem';
+
+describe('Simple DropdownMenu', () => {
+  let dropdownMenu;
+  let rsDropdown;
+  let rsDropdownToggle;
+  let rsDropdownMenu;
+
+  beforeAll(() => {
+    dropdownMenu = shallow(
+      <DropdownMenu>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown);
+    rsDropdownToggle = dropdownMenu.find(RSDropdownToggle);
+    rsDropdownMenu = dropdownMenu.find(RSDropdownMenu);
+  })
+
+  it('should create a reacstrap Dropdown', () =>
+    expect(rsDropdown).toHaveLength(1));
+
+  it('should create a reactstrap toggle', () =>
+    expect(rsDropdownToggle).toHaveLength(1));
+
+  it('should create a reactstrap dropdown menu', () =>
+    expect(rsDropdownMenu).toHaveLength(1));
+})

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -54,4 +54,58 @@ describe('Simple DropdownMenu', () => {
     expect(dropdownMenu.find(RSDropdown).prop('isOpen')).toBe(false)
   })
 
+  afterAll(() => {
+    dropdownMenu.unmount()
+  })
+
+})
+
+describe('DropdownMenu - options', () => {
+
+  let dropdownMenu;
+  let rsDropdown;
+  let rsDropdownToggle;
+  let rsDropdownMenu;
+
+  it('in_navbar', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" in_navbar={true}>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown);
+
+    expect(rsDropdown.prop('inNavbar')).toBe(true)
+  })
+
+  it('disabled', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" disabled={true}>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown);
+    rsDropdownToggle = dropdownMenu.find(RSDropdownToggle);
+
+    expect(rsDropdown.prop('disabled')).toBe(true)
+    expect(rsDropdownToggle.prop('disabled')).toBe(true)
+  })
+
+  it('nav', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" nav={true}>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown);
+    rsDropdownToggle = dropdownMenu.find(RSDropdownToggle);
+
+    expect(rsDropdown.prop('nav')).toBe(true)
+    expect(rsDropdownToggle.prop('nav')).toBe(true)
+  })
+
+  afterEach(() => {
+    dropdownMenu.unmount();
+  })
+
 })


### PR DESCRIPTION
Passing the addon_type prop to `DropdownMenu` allows embedding dropdowns in input groups. For instance:

![screen shot 2018-11-16 at 13 41 44](https://user-images.githubusercontent.com/1392879/48624832-62b98080-e9a5-11e8-9230-314fec44c574.png)

See below for the code used to generate that app. The value in the `Input` is generated dynamically as the dropdown changes.

This PR also adds unit tests for `DropdownMenu`.

This resolves issue #52 and allows me to finish PR #51 .

-----

Test code:

```py

import dash
import dash_bootstrap_components as dbc
import dash_html_components as html
import dash_core_components as dcc
from dash.dependencies import Input, Output

app = dash.Dash(
    __name__, 
    external_stylesheets=['https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css']
)

app.layout = dbc.Container([
    html.H2('Dropdown add on type demonstration'),
    dbc.InputGroup(
        [
            dbc.DropdownMenu(
                [
                    dbc.DropdownMenuItem("hello", id="demo-input-hello"),
                    dbc.DropdownMenuItem("world", id="demo-input-world")
                ],
                addon_type="prepend",
                label="Label"
            ),
            dbc.Input(placeholder='username', id="demo-output")
        ]
    )
])


@app.callback(
    Output("demo-output", "value"),
    [Input("demo-input-hello", "n_clicks_timestamp"), Input("demo-input-world", "n_clicks_timestamp")]
)
def _(t_click_hello, t_click_world):
    if not t_click_hello and not t_click_world:
        return ''
    elif t_click_hello is None:
        return 'world'
    elif t_click_world is None:
        return 'hello'
    elif t_click_hello <= t_click_world:
        return 'world'
    else:
        return 'hello'
    
    
if __name__ == '__main__':
    app.run_server(port=8888, debug=True)
```
