### PR TITLE
Add bs_size prop to DropdownMenu

### DIFF
--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -30,6 +30,7 @@ class DropdownMenu extends React.Component {
       caret,
       in_navbar,
       addon_type,
+      bs_size,
       ...otherProps
     } = this.props;
     return (
@@ -40,6 +41,7 @@ class DropdownMenu extends React.Component {
         disabled={disabled}
         inNavbar={in_navbar}
         addonType={addon_type}
+        size={bs_size}
         {...otherProps}
       >
         <DropdownToggle nav={nav} caret={caret} disabled={disabled}>
@@ -115,7 +117,9 @@ DropdownMenu.propTypes = {
   /**
    * Add caret to dropdown toggle
    */
-  caret: PropTypes.bool
+  caret: PropTypes.bool,
+
+  bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 
 export default DropdownMenu;

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -119,6 +119,10 @@ DropdownMenu.propTypes = {
    */
   caret: PropTypes.bool,
 
+  /**
+   * Size of the dropdown. `sm` corresponds to small, `md` to medium
+   * and `lg` to large.
+   */
   bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -123,7 +123,7 @@ DropdownMenu.propTypes = {
    * Size of the dropdown. `sm` corresponds to small, `md` to medium
    * and `lg` to large.
    */
-  bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  bs_size: PropTypes.oneOf(['sm', 'md', 'lg'])
 };
 
 export default DropdownMenu;

--- a/src/components/__tests__/DropdownMenu.test.js
+++ b/src/components/__tests__/DropdownMenu.test.js
@@ -164,6 +164,28 @@ describe('DropdownMenu - options', () => {
     expect(rsDropdown.prop('addonType')).toEqual('append')
   })
 
+  it('bs_size -- undefined', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label">
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('size')).toBeUndefined()
+  })
+
+  it('bs_size -- defined', () => {
+    dropdownMenu = shallow(
+      <DropdownMenu label="Label" bs_size="sm">
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+      </DropdownMenu>
+    )
+    rsDropdown = dropdownMenu.find(RSDropdown)
+
+    expect(rsDropdown.prop('size')).toEqual('sm')
+  })
+
   afterEach(() => {
     dropdownMenu.unmount();
   })


### PR DESCRIPTION
This PR allows passing the `bs_size` prop to `DropdownMenu`.

For a demo of this:

<img width="809" alt="screen shot 2018-11-17 at 14 02 37" src="https://user-images.githubusercontent.com/1392879/48661912-a5488f00-ea71-11e8-8d05-c8fbf7ce46ed.png">


```py
import dash
import dash_html_components as html
import dash_bootstrap_components as dbc

app = dash.Dash(
    __name__, 
    external_stylesheets=['https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css']
)

items = [
    dbc.DropdownMenuItem('item 1'),
    dbc.DropdownMenuItem('item 2'),
    dbc.DropdownMenuItem('item 3'),
]

app.layout = dbc.Container([
    html.H2('Dropdown size demonstration', className="mb-5"),
    dbc.DropdownMenu(items, label="@lg", bs_size="lg", className="mb-3"),
    dbc.DropdownMenu(items, label="@md", bs_size="md", className="mb-3"),
    dbc.DropdownMenu(items, label="@sm", bs_size="sm")
])


if __name__ == '__main__':
    app.run_server(port=8888, debug=True)
```