### PR TITLE
Disable opening dropdown menus upwards

### DIFF
--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -87,9 +87,10 @@ DropdownMenu.propTypes = {
   label: PropTypes.string,
 
   /**
-   * Direction in which to expand the dropdown.
+   * Direction in which to expand the dropdown. Note that expanding
+   * the dropdown upwards is currently unsupported.
    */
-  direction: PropTypes.oneOf(['up', 'down', 'left', 'right']),
+  direction: PropTypes.oneOf(['down', 'left', 'right']),
 
   /**
    * For Dropdown usage inside a Navbar (disables popper)


### PR DESCRIPTION
Following the discussion in issue #62 , this disables setting the dropdown direction to `up`.

Since dash does not explicitly validate the `oneOf` prop type, this is not actually enforced at the moment: there is nothing stopping a user from passing `up` to the `direction` prop. The only value of this PR is for the docstrings.

If we want to enforce disallowing up, we would have to catch it in `render` and display a console warning or something of the sort. Obviously, in an ideal world, Dash would enforce the `oneOf` prop type on the Python side.