### PR TITLE
Check that twine and npm are present on the system before starting releasing

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
 from pathlib import Path
-from subprocess import call
 from shutil import which
+from subprocess import call
 
 import semver
 from invoke import run as invoke_run

--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 from subprocess import call
+from shutil import which
 
 import semver
 from invoke import run as invoke_run
@@ -193,20 +194,14 @@ def open_editor(initial_message):
 
 
 def check_prerequisites():
-    result = invoke_run("which twine", hide=True)
-    if result.exited != 0:
-        error(
-            "twine executable not found. "
-            "You must have twine to run this command."
-        )
-        exit(result.exited)
-    result = invoke_run("which npm", hide=True)
-    if result.exited != 0:
-        error(
-            "npm executable not found. "
-            "You must have npm to run this command."
-        )
-        exit(result.exited)
+    for executable in ["twine", "npm"]:
+        if which(executable) is None:
+            error(
+                f"{executable} executable not found. "
+                f"You must have {executable} to release "
+                "dash-bootstrap-components."
+            )
+            exit(127)
 
 
 def normalize_version(version):

--- a/tasks.py
+++ b/tasks.py
@@ -31,6 +31,7 @@ def prerelease(ctx, version):
      - Bump the version number
      - Push a release to pypi
     """
+    check_prerequisites()
     info(f"Releasing version {version} as prerelease")
     build_publish(version)
 
@@ -48,6 +49,7 @@ def release(ctx, version):
      - commit the version changes to source control
      - tag the commit
     """
+    check_prerequisites()
     info(f"Releasing version {version} as full release")
     release_notes_lines = get_release_notes(version)
 
@@ -188,6 +190,23 @@ def open_editor(initial_message):
         lines = f.readlines()
 
     return lines
+
+
+def check_prerequisites():
+    result = invoke_run("which twine", hide=True)
+    if result.exited != 0:
+        error(
+            "twine executable not found. "
+            "You must have twine to run this command."
+        )
+        exit(result.exited)
+    result = invoke_run("which npm", hide=True)
+    if result.exited != 0:
+        error(
+            "npm executable not found. "
+            "You must have npm to run this command."
+        )
+        exit(result.exited)
 
 
 def normalize_version(version):


### PR DESCRIPTION
Prior to this PR, if twine was missing, `invoke prerelease` or `invoke release` would spend a few minutes building the JS bundle and then crash. This introduces a minimal check that the release can actually happen.