### PR TITLE
Support internal and external links in list group items

### DIFF
--- a/src/components/DropdownMenuItem.js
+++ b/src/components/DropdownMenuItem.js
@@ -12,13 +12,11 @@ class DropdownMenuItem extends React.Component {
   }
 
   incrementClicks() {
-    if (!this.props.disabled) {
-      if (this.props.setProps) {
-        this.props.setProps({
-          n_clicks: this.props.n_clicks + 1,
-          n_clicks_timestamp: Date.now()
-        });
-      }
+    if (!this.props.disabled && this.props.setProps) {
+      this.props.setProps({
+        n_clicks: this.props.n_clicks + 1,
+        n_clicks_timestamp: Date.now()
+      });
     }
   }
 

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -22,10 +22,11 @@ class ListGroupItem extends React.Component {
   }
 
   render() {
-    let {children, href, ...otherProps} = this.props;
+    let {children, ...otherProps} = this.props;
+    const {href, disabled} = this.props;
     otherProps[href ? 'preOnClick' : 'onClick'] = this.incrementClicks;
     return (
-      <RSListGroupItem tag={href ? Link : 'li'} href={href} {...otherProps}>
+      <RSListGroupItem tag={href && !disabled ? Link : 'li'} {...otherProps}>
         {children}
       </RSListGroupItem>
     );

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -11,22 +11,20 @@ class ListGroupItem extends React.Component {
   }
 
   incrementClicks() {
-    if (!this.props.disabled) {
-      if (this.props.setProps) {
-        this.props.setProps({
-          n_clicks: this.props.n_clicks + 1,
-          n_clicks_timestamp: Date.now()
-        });
-      }
+    if (!this.props.disabled && this.props.setProps) {
+      this.props.setProps({
+        n_clicks: this.props.n_clicks + 1,
+        n_clicks_timestamp: Date.now()
+      });
     }
   }
 
   render() {
     let {children, ...otherProps} = this.props;
-    const {href, disabled} = this.props;
-    otherProps[href ? 'preOnClick' : 'onClick'] = this.incrementClicks;
+    const useLink = this.props.href && !this.props.disabled;
+    otherProps[useLink ? 'preOnClick' : 'onClick'] = this.incrementClicks;
     return (
-      <RSListGroupItem tag={href && !disabled ? Link : 'li'} {...otherProps}>
+      <RSListGroupItem tag={useLink ? Link : 'li'} {...otherProps}>
         {children}
       </RSListGroupItem>
     );


### PR DESCRIPTION
This PR adds support for internal and external links to `ListGroupItem`, the implementation is very much the same as that for `DropdownMenuItem`.

The changes can be tested with the following simple app

```python
import dash
import dash_bootstrap_components as dbc
import dash_html_components as html
from dash.dependencies import Input, Output

app = dash.Dash()

app.layout = dbc.Container(
    [
        dbc.ListGroup(
            [
                dbc.ListGroupItem("Normal item"),
                dbc.ListGroupItem("Internal link", href="/internal"),
                dbc.ListGroupItem(
                    "Relative link", href="/relative", external_link=True
                ),
                dbc.ListGroupItem("External link", href="https://google.com"),
                dbc.ListGroupItem("Button", id="button-item", n_clicks=0),
                dbc.ListGroupItem(
                    [
                        dbc.ListGroupItemHeading("Item with heading"),
                        dbc.ListGroupItemText("and text"),
                    ],
                    href="/internal2",
                ),
            ]
        ),
        html.P(id="counter"),
    ]
)


@app.callback(
    Output("counter", "children"), [Input("button-item", "n_clicks")]
)
def count(n):
    return f"Button has been clicked {n} times"


if __name__ == "__main__":
    app.run_server(port=8888)

```