### PR TITLE
Fix hover behaviour of disabled DropdownMenuItems

### DIFF
--- a/src/components/DropdownMenuItem.js
+++ b/src/components/DropdownMenuItem.js
@@ -24,9 +24,16 @@ class DropdownMenuItem extends React.Component {
 
   render() {
     let {children, href, ...otherProps} = this.props;
-    otherProps[href ? 'preOnClick' : 'onClick'] = this.incrementClicks;
+    const useLink = href && !this.props.disabled;
+    otherProps[useLink ? 'preOnClick' : 'onClick'] = this.incrementClicks;
     return (
-      <RSDropdownItem tag={href ? Link : 'button'} href={href} {...otherProps}>
+      <RSDropdownItem
+        tag={useLink ? Link : 'button'}
+        // don't pass href if disabled otherwise reactstrap renders item
+        // as link and the cursor becomes a pointer on hover
+        href={this.props.disabled ? null : href}
+        {...otherProps}
+      >
         {children}
       </RSDropdownItem>
     );


### PR DESCRIPTION
This PR improves the hover behaviour of disabled `DropdownMenuItem` components, by preventing `<a>` elements being used to render disabled items. This previously resulted in pointer cursor appearing when hovering, suggesting the item was clickable when it isn't. 