### PR TITLE
Apidoc fix

### DIFF
--- a/docs/components_page/api_doc.py
+++ b/docs/components_page/api_doc.py
@@ -1,7 +1,7 @@
 from itertools import chain
 
 import dash_html_components as html
-from dash.development.base_component import (
+from dash.development._py_components_generation import (
     filter_props,
     js_to_py_type,
     parse_events,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+dash==0.31.1
 dash_bootstrap_components==0.2.2
 dash_core_components
 dash_html_components


### PR DESCRIPTION
This PR addresses #87.

The issue arose due to [this commit](https://github.com/plotly/dash/commit/4878245f2ead071bb5e78364be5c07c94e598b60#diff-7221a92fb7bc030889d57fabc119adfa) in the Dash repo that moved some of the internal functions we were relying on for the API documentation generation. I've fixed the import and also pinned the version of Dash required for the docs for good measure.