### PR TITLE
Check dash-generate-components exists before releasing

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -194,7 +194,7 @@ def open_editor(initial_message):
 
 
 def check_prerequisites():
-    for executable in ["twine", "npm"]:
+    for executable in ["twine", "npm", "dash-generate-components"]:
         if which(executable) is None:
             error(
                 f"{executable} executable not found. "


### PR DESCRIPTION
The executable dash-generate-components is now a prerequisite to releasing. We should therefore check that it exists.

It can be installed with `pip install dash`.