### PR TITLE
Explicitly import React in pure components

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,8 +6,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-  <script type="text/javascript" src="https://unpkg.com/react@15.4.2/dist/react.min.js"></script>
-  <script type="text/javascript" src="https://unpkg.com/react-dom@15.4.2/dist/react-dom.min.js"></script>
 </head>
 
 <body>

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Alert as RSAlert} from 'reactstrap';
 

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Badge as RSBadge} from 'reactstrap';
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Button as RSButton} from 'reactstrap';
 

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {ButtonGroup as RSButtonGroup} from 'reactstrap';
 

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Collapse as RSCollapse} from 'reactstrap';
 

--- a/src/components/Fade.js
+++ b/src/components/Fade.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Fade as RSFade} from 'reactstrap';
 

--- a/src/components/Jumbotron.js
+++ b/src/components/Jumbotron.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Jumbotron as RSJumbotron} from 'reactstrap';
 

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Label as RSLabel} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Popover as RSPopover} from 'reactstrap';
 

--- a/src/components/PopoverBody.js
+++ b/src/components/PopoverBody.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {PopoverBody as RSPopoverBody} from 'reactstrap';
 

--- a/src/components/PopoverHeader.js
+++ b/src/components/PopoverHeader.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {PopoverHeader as RSPopoverHeader} from 'reactstrap';
 

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Progress as RSProgress} from 'reactstrap';
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Table as RSTable} from 'reactstrap';
 

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Card as RSCard} from 'reactstrap';
 

--- a/src/components/card/CardBody.js
+++ b/src/components/card/CardBody.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardBody as RSCardBody} from 'reactstrap';
 

--- a/src/components/card/CardColumns.js
+++ b/src/components/card/CardColumns.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardColumns as RSCardColumns} from 'reactstrap';
 

--- a/src/components/card/CardDeck.js
+++ b/src/components/card/CardDeck.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardDeck as RSCardDeck} from 'reactstrap';
 

--- a/src/components/card/CardFooter.js
+++ b/src/components/card/CardFooter.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardFooter as RSCardFooter} from 'reactstrap';
 

--- a/src/components/card/CardGroup.js
+++ b/src/components/card/CardGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardGroup as RSCardGroup} from 'reactstrap';
 

--- a/src/components/card/CardHeader.js
+++ b/src/components/card/CardHeader.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardHeader as RSCardHeader} from 'reactstrap';
 

--- a/src/components/card/CardImg.js
+++ b/src/components/card/CardImg.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardImg as RSCardImg} from 'reactstrap';
 

--- a/src/components/card/CardImgOverlay.js
+++ b/src/components/card/CardImgOverlay.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardImgOverlay as RSCardImgOverlay} from 'reactstrap';
 

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {CardLink as RSCardLink} from 'reactstrap';

--- a/src/components/card/CardSubtitle.js
+++ b/src/components/card/CardSubtitle.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardSubtitle as RSCardSubtitle} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/card/CardTitle.js
+++ b/src/components/card/CardTitle.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {CardTitle as RSCardTitle} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Form as RSForm} from 'reactstrap';
 

--- a/src/components/form/FormFeedback.js
+++ b/src/components/form/FormFeedback.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {FormFeedback as RSFormFeedback} from 'reactstrap';
 

--- a/src/components/form/FormGroup.js
+++ b/src/components/form/FormGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {FormGroup as RSFormGroup} from 'reactstrap';
 

--- a/src/components/form/FormText.js
+++ b/src/components/form/FormText.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {FormText as RSFormText} from 'reactstrap';
 

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {append, contains, without} from 'ramda';
-import React from 'react';
 import classNames from 'classnames';
 
 /**

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -1,8 +1,8 @@
+import React from 'react';
 import {DateRangePicker} from 'react-dates';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
-import React, {Component} from 'react';
 import classNames from 'classnames';
 import './react-dates@12.3.0.css';
 
@@ -22,7 +22,7 @@ const sizeMap = {
  * This component is based off of Airbnb's react-dates react component
  * which can be found here: https://github.com/airbnb/react-dates
  */
-export default class DatePickerRange extends Component {
+export default class DatePickerRange extends React.Component {
   constructor() {
     super();
     this.propsToState = this.propsToState.bind(this);

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -1,8 +1,8 @@
+import React from 'react';
 import {SingleDatePicker} from 'react-dates';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
-import React, {Component} from 'react';
 import classNames from 'classnames';
 import './react-dates@12.3.0.css';
 
@@ -22,7 +22,7 @@ const sizeMap = {
  * This component is based off of Airbnb's react-dates react component
  * which can be found here: https://github.com/airbnb/react-dates
  */
-export default class DatePickerSingle extends Component {
+export default class DatePickerSingle extends React.Component {
   constructor() {
     super();
     this.propsToState = this.propsToState.bind(this);

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {InputGroup as RSInputGroup} from 'reactstrap';
 

--- a/src/components/input/InputGroupAddon.js
+++ b/src/components/input/InputGroupAddon.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import InputGroupText from './InputGroupText';

--- a/src/components/input/InputGroupText.js
+++ b/src/components/input/InputGroupText.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {InputGroupText as RSInputGroupText} from 'reactstrap';
 

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/src/components/layout/Col.js
+++ b/src/components/layout/Col.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Col as RSCol} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/layout/Container.js
+++ b/src/components/layout/Container.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Container as RSContainer} from 'reactstrap';
 

--- a/src/components/layout/Row.js
+++ b/src/components/layout/Row.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Row as RSRow} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/listgroup/ListGroup.js
+++ b/src/components/listgroup/ListGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {ListGroup as RSListGroup} from 'reactstrap';
 

--- a/src/components/listgroup/ListGroupItemHeading.js
+++ b/src/components/listgroup/ListGroupItemHeading.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {ListGroupItemHeading as RSListGroupItemHeading} from 'reactstrap';
 

--- a/src/components/listgroup/ListGroupItemText.js
+++ b/src/components/listgroup/ListGroupItemText.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {ListGroupItemText as RSListGroupItemText} from 'reactstrap';
 import classNames from 'classnames';

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {Nav as RSNav} from 'reactstrap';
 

--- a/src/components/nav/NavItem.js
+++ b/src/components/nav/NavItem.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {NavItem as RSNavItem} from 'reactstrap';
 

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Link from '../../private/Link';
 

--- a/src/components/nav/NavbarBrand.js
+++ b/src/components/nav/NavbarBrand.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {NavbarBrand as RSNavbarBrand} from 'reactstrap';
 import Link from '../../private/Link';

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {NavbarToggler as RSNavbarToggler} from 'reactstrap';
 


### PR DESCRIPTION
Quite a lot of our components are so-called functional React components. They are defined as a function rather than as a class:

```js
const Alert = props => { /* do something */ }
```

While there is no explicit dependency on React, functional components still require having:

```js
import React from 'react'
```

... at the top.  This is because functional components desugar to explicit calls to `React.createComponent`, as explained [here](https://hackernoon.com/why-import-react-from-react-in-a-functional-component-657aed821f7a).

So far, this hasn't actually caused us any issues because:

- in the demo, we explicitly imported react and react-dom in `<script />` tags. This injects `React` into the global namespace, so the components still worked.
- in the actual generated components, Dash intentionally requires React to be injected from the outside so it doesn't matter whether we explicitly set it in components. To avoid bundling React ourselves (which would duplicate it, since Dash already provides it), we declare it as an external dependency in `webpack.config.dist.js`. This tells webpack to just assume the keyword `React` exists in the global namespace.

This needs to be fixed to allow embedding *dash-bootstrap-components* into third party JS libraries. For this, we need to distribute *dash-bootstrap-components* as a UMD distribution. We will probably want to declare react and react-dom as external libraries ([reactstrap do this too](https://github.com/reactstrap/reactstrap/blob/master/webpack.base.config.js#L42)). For this to work, the imports need to be correct.