### PR TITLE
Add CDN link for Bootstrap Grid CSS to themes, and document layout components

### DIFF
--- a/dash_bootstrap_components/themes.py
+++ b/dash_bootstrap_components/themes.py
@@ -2,6 +2,9 @@ BOOTSTRAP = (
     "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
 )
 
+# Grid only
+GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap-grid.min.css"  # noqa
+
 _BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.1.3/"
 
 CERULEAN = _BOOTSWATCH_BASE + "cerulean/bootstrap.min.css"

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -95,6 +95,10 @@ span.hljs-meta {
   border-radius: 0px 0px 3px 3px;
 }
 
+.source-container>pre.hljs {
+  border-radius: 3px;
+}
+
 .api-documentation {
   margin-bottom: 4rem;
 }

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -31,10 +31,10 @@ def get_content(app):
         html.H2("Input components"),
         html.P(
             dcc.Markdown(
-                "`dash-bootstrap-components` has its own versions of some of "
-                "the input components available in `dash-core-components`. "
+                "*dash-bootstrap-components* has its own versions of some of "
+                "the input components available in *dash-core-components*. "
                 "They have been designed to share the same interface as the "
-                "corresponding components in `dash-core-components` for "
+                "corresponding components in *dash-core-components* for "
                 "familiarity, but have a few additional Bootstrap specific "
                 "features."
             )
@@ -91,7 +91,7 @@ def get_content(app):
         html.P(
             dcc.Markdown(
                 "The `Textarea` component works like the "
-                "`dash-core-components` analogue, but accepts the additional "
+                "*dash-core-components* analogue, but accepts the additional "
                 "arguments `valid`, `invalid`, and `bs_size` much like "
                 "`Input`."
             )
@@ -102,7 +102,7 @@ def get_content(app):
         html.P(
             dcc.Markdown(
                 "`RadioItems` and `Checklist` components also work like "
-                "`dash-core-components` but again with Bootstrap styles "
+                "*dash-core-components* but again with Bootstrap styles "
                 "added. In addition the `inline` keyword can be used to "
                 "easily make inline checklists or radioitems. Use these "
                 "components with `FormGroup` for automatic spacing and "

--- a/docs/components_page/components/layout/__init__.py
+++ b/docs/components_page/components/layout/__init__.py
@@ -47,7 +47,7 @@ content = html.Div(
         html.P(
             dcc.Markdown(
                 "There are three main layout components in "
-                "`dash-bootstrap-components`: `Container`, `Row`, and `Col`."
+                "*dash-bootstrap-components*: `Container`, `Row`, and `Col`."
             )
         ),
         html.P(
@@ -55,7 +55,7 @@ content = html.Div(
                 "The `Container` component can be used to center and "
                 "horizontally pad your app's content. The docs you are "
                 "currently reading are themselves a Dash app built with "
-                "`dash-bootstrap-components`. The content on this page has "
+                "*dash-bootstrap-components*. The content on this page has "
                 "been centered by wrapping it in a `Container` component. By "
                 "default the container has a responsive pixel width. Use the "
                 "keyword argument `fluid=True` if you want your `Container` "
@@ -64,7 +64,7 @@ content = html.Div(
         ),
         html.P(
             dcc.Markdown(
-                "The `Row` component is a wrapper for columns, the layout of "
+                "The `Row` component is a wrapper for columns. The layout of "
                 "your app should be built as a series of rows of columns."
             )
         ),
@@ -94,34 +94,17 @@ content = html.Div(
         HighlightedSource(layout_simple_source),
         html.H4("Specify width"),
         html.P(
-            [
+            dcc.Markdown(
                 "Specify the desired width of each column using the `width` "
-                "keyword argument. The basic options are:",
-                html.Ul(
-                    [
-                        html.Li(
-                            dcc.Markdown(
-                                "`True`, the default, column will expand to "
-                                "fill the available space."
-                            )
-                        ),
-                        html.Li(
-                            dcc.Markdown(
-                                '`"auto"`, column will be sized according to '
-                                "the natural width of its content."
-                            )
-                        ),
-                        html.Li(
-                            dcc.Markdown(
-                                "An integer `1`,...,`12`. Column will span "
-                                "this many of the 12 grid columns. For a half "
-                                "width column, set `width=6`, for a third "
-                                "width column, set `width=4`, and so on."
-                            )
-                        ),
-                    ]
-                ),
-            ]
+                "keyword argument. The basic options are:\n\n"
+                "- `True`, the default, column will expand to fill the "
+                "available space.\n"
+                '- `"auto"`, column will be sized according to the natural '
+                "width of its content.\n"
+                "- An integer `1`,...,`12`. Column will span this many of the "
+                "12 grid columns. For a half width column, set `width=6`, for "
+                "a third width column, set `width=4`, and so on."
+            )
         ),
         ExampleContainer(layout_width),
         HighlightedSource(layout_width_source),
@@ -168,7 +151,7 @@ content = html.Div(
                 "or extra large devices using the `xs`, `sm`, `md`, `lg`, and "
                 "`xl` keyword arguments. Each takes the same arguments as "
                 "`width` and specifies the column behaviour for that size of "
-                "screen or larger. `width` secretly just sets `xs`, if you "
+                "screen or larger. `width` secretly just sets `xs`. If you "
                 "specify both, `xs` will override `width`."
             )
         ),
@@ -203,7 +186,7 @@ content = html.Div(
         html.H4("Row without 'gutters'"),
         html.P(
             dcc.Markdown(
-                "By default, horizontal spacing is added between the columns."
+                "By default, horizontal spacing is added between the columns. "
                 "Use `no_gutters=True` to disable this."
             )
         ),

--- a/docs/components_page/components/layout/__init__.py
+++ b/docs/components_page/components/layout/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import dash_core_components as dcc
 import dash_html_components as html
 
 from ...api_doc import ApiDoc
@@ -15,6 +16,10 @@ from .width import row as layout_width
 
 HERE = Path(__file__).parent
 
+BOOTSTRAP_DOWNLOAD = (
+    "https://getbootstrap.com/docs/4.2/getting-started/download/"
+)
+
 layout_simple_source = (HERE / "simple.py").read_text()
 layout_width_source = (HERE / "width.py").read_text()
 layout_order_offset_source = (HERE / "order_offset.py").read_text()
@@ -22,25 +27,201 @@ layout_breakpoints_source = (HERE / "breakpoints.py").read_text()
 layout_no_gutters_source = (HERE / "no_gutters.py").read_text()
 layout_vertical_source = (HERE / "vertical.py").read_text()
 layout_horizontal_source = (HERE / "horizontal.py").read_text()
+grid_only_source = (HERE / "grid_only.py").read_text()
 
 content = html.Div(
     [
-        html.H2("Row with columns"),
+        html.H2("Layout"),
+        html.P(
+            dcc.Markdown(
+                "Layout in Bootstrap is controlled using the grid system. The "
+                "Bootstrap grid has twelve columns, and five responsive tiers "
+                "(allowing you to specify different behaviours on different "
+                "screen sizes, see below). The width of your columns can be "
+                "specified in terms of how many of the twelve grid columns it "
+                "should span, or you can allow the columns to expand or "
+                "shrink to fit either their content or the available space in "
+                "the row."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "There are three main layout components in "
+                "`dash-bootstrap-components`: `Container`, `Row`, and `Col`."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "The `Container` component can be used to center and "
+                "horizontally pad your app's content. The docs you are "
+                "currently reading are themselves a Dash app built with "
+                "`dash-bootstrap-components`. The content on this page has "
+                "been centered by wrapping it in a `Container` component. By "
+                "default the container has a responsive pixel width. Use the "
+                "keyword argument `fluid=True` if you want your `Container` "
+                "to fill available horizontal space and resize fluidly."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "The `Row` component is a wrapper for columns, the layout of "
+                "your app should be built as a series of rows of columns."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "When using the grid layout, content should be placed in "
+                "columns, and only `Col` components should be immediate "
+                "children of `Row`."
+            )
+        ),
+        html.P(
+            [
+                "For much more detail on the Bootstrap grid system, see the ",
+                html.A(
+                    "Bootstrap documentation",
+                    href="https://getbootstrap.com/docs/4.2/layout/grid/",
+                ),
+                ".",
+            ]
+        ),
+        html.H4("Row with columns"),
+        html.P(
+            "By default, columns will have equal width and will expand to "
+            "fill available space."
+        ),
         ExampleContainer(layout_simple),
         HighlightedSource(layout_simple_source),
         html.H4("Specify width"),
+        html.P(
+            [
+                "Specify the desired width of each column using the `width` "
+                "keyword argument. The basic options are:",
+                html.Ul(
+                    [
+                        html.Li(
+                            dcc.Markdown(
+                                "`True`, the default, column will expand to "
+                                "fill the available space."
+                            )
+                        ),
+                        html.Li(
+                            dcc.Markdown(
+                                '`"auto"`, column will be sized according to '
+                                "the natural width of its content."
+                            )
+                        ),
+                        html.Li(
+                            dcc.Markdown(
+                                "An integer `1`,...,`12`. Column will span "
+                                "this many of the 12 grid columns. For a half "
+                                "width column, set `width=6`, for a third "
+                                "width column, set `width=4`, and so on."
+                            )
+                        ),
+                    ]
+                ),
+            ]
+        ),
         ExampleContainer(layout_width),
         HighlightedSource(layout_width_source),
         html.H4("Specify order and offset"),
+        html.P(
+            dcc.Markdown(
+                "In addition to the simple width arguments outlined above, "
+                "you can pass a dictionary of values to `width`. The "
+                "dictionary can have keys `size`, `order` and `offset`."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "`size` takes any of the simple arguments that `width` "
+                'understands, i.e. `True`, "auto", or an integer `1`,...,`12`,'
+                " and specifies the size / width of the column."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "`order` can be used to reorder the columns. It accepts the "
+                'integers `1`,...,`12`, or the strings `"first"` and `"last"`.'
+                " Columns will then be ordered numerically, with columns "
+                'specified as `"first"` or `"last"` being placed first and '
+                "last respectively. If two columns have the same order, they "
+                "will keep the order they are specified in the source."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "Finally `offset` accepts the integers `1`, ..., `12` and "
+                "increases the left margin of the column by that number of "
+                "grid columns."
+            )
+        ),
         ExampleContainer(layout_order_offset),
         HighlightedSource(layout_order_offset_source),
         html.H4("Specify width for different screen sizes"),
+        html.P(
+            dcc.Markdown(
+                "Bootstrap’s grid includes five responsive tiers for building "
+                "complex responsive layouts. Customize the size, order and "
+                "offset of your columns on extra small, small, medium, large, "
+                "or extra large devices using the `xs`, `sm`, `md`, `lg`, and "
+                "`xl` keyword arguments. Each takes the same arguments as "
+                "`width` and specifies the column behaviour for that size of "
+                "screen or larger. `width` secretly just sets `xs`, if you "
+                "specify both, `xs` will override `width`."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "The first of the following two examples has three columns, "
+                "we set `md=4` indicating that on a 'medium' sized or larger "
+                "screen each column should take up a third of the width. "
+                "Since we don't specify behaviour on smaller size screens "
+                "Bootstrap will allow the rows to wrap so as not to squash "
+                "the content. You will see this happening if you resize the "
+                "window you are reading this in."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "In the second example we set `lg=3`, indicating that on a "
+                "'large' sized or larger screen each column should take up a "
+                "quarter of the width of the row. We also set `width=6`, "
+                "indicating that the default width of each column should be "
+                "half of the available width of the row. Again you will see "
+                "this behaviour if you resize this window."
+            )
+        ),
+        html.P(
+            "By setting different sizes, orders and offsets for the different "
+            "responsive tiers you can build very complex layouts without the "
+            "need for writing your own CSS or inline styles."
+        ),
         ExampleContainer(layout_breakpoints),
         HighlightedSource(layout_breakpoints_source),
         html.H4("Row without 'gutters'"),
+        html.P(
+            dcc.Markdown(
+                "By default, horizontal spacing is added between the columns."
+                "Use `no_gutters=True` to disable this."
+            )
+        ),
         ExampleContainer(layout_no_gutters),
         HighlightedSource(layout_no_gutters_source),
         html.H4("Vertical alignment"),
+        html.P(
+            dcc.Markdown(
+                "Control the vertical alignment of each column in the row "
+                "using the `align` keyword. You can specify a value for "
+                "`align` in either the `Col` component or its parent `Row`. "
+                "If you specify a value for `align` in the `Col` it will "
+                "overrule any value specified in the parent `Row`. The "
+                'available options are `"start"`, `"center"`, `"end"` which '
+                "align the columns along the top, center, and bottom of the "
+                "row respectively."
+            )
+        ),
         html.Div(
             [
                 ExampleContainer(layout_vertical),
@@ -49,8 +230,52 @@ content = html.Div(
             className="pad-row",
         ),
         html.H4("Horizontal alignment"),
+        html.P(
+            dcc.Markdown(
+                "You can also control horizontal alignment of columns using "
+                "the `justify` keyword argument of `Row`. The options are "
+                '`"start"`, `"center"`, `"end"`, `"between"` and `"around"`.'
+            )
+        ),
         ExampleContainer(layout_horizontal),
         HighlightedSource(layout_horizontal_source),
+        html.H4("Using only the grid components"),
+        html.P(
+            dcc.Markdown(
+                "Sometimes you may wish to use Bootstrap's grid system for "
+                "specifying the layout of your app, but you don't want the "
+                "changes Bootstrap makes to the typography, or to load all "
+                "the additional CSS classes that Bootstrap specifies. In such "
+                "a situation, you can link only the CSS required for the grid "
+                "system using the `themes` module."
+            )
+        ),
+        html.Div(
+            dcc.SyntaxHighlighter(
+                grid_only_source, language="python", useInlineStyles=False
+            ),
+            className="source-container",
+        ),
+        html.P(
+            [
+                "Alternatively download ",
+                html.Code("bootstrap-grid.css"),
+                " from the ",
+                html.A("Bootstrap website", href=BOOTSTRAP_DOWNLOAD),
+                " and place it in your app's ",
+                html.Code("assets/"),
+                " directory. See the ",
+                html.A(
+                    "Plotly Dash documentation",
+                    href="https://dash.plot.ly/external-resources",
+                ),
+                " for details.",
+            ]
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/layout/Container.js"),
+            component_name="Container",
+        ),
         ApiDoc(
             get_component_metadata("src/components/layout/Row.js"),
             component_name="Row",

--- a/docs/components_page/components/layout/grid_only.py
+++ b/docs/components_page/components/layout/grid_only.py
@@ -1,0 +1,4 @@
+import dash
+import dash_bootstrap_components as dbc
+
+app = dash.Dash(external_stylesheets=[dbc.themes.GRID])

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="container">
-      <div class="row justify-content-sm-center">
+      <div class="row justify-content-sm-center pb-5">
         <div class="col">
           <h2 class="section-header">Installation</h2>
           <hr />
@@ -124,6 +124,32 @@ app.layout = html.Div([navbar, body])
 
 if __name__ == "__main__":
     app.run_server()</code></pre>
+          <h2 class="section-header mt-5">Using just the grid system</h2>
+          <hr />
+          <p>
+            Sometimes you may wish to take advantage of Bootstrap's grid system
+            for controlling the layout of your app, without including all of the
+            typography changes and additional CSS classes that come with it. In
+            such scenarios, it's possible to link just the
+            <code>bootstrap-grid.css</code> stylesheet. The easiest way to do this
+            is to use the CDN link in the <code>themes</code> module:
+          </p>
+          <pre><code class="language-python">app = dash.Dash(__name__, external_stylesheets=[dbc.themes.GRID])</code></pre>
+          <p>
+            If you prefer, you can also
+            <a href="https://getbootstrap.com/docs/4.2/getting-started/download/">download</a>
+            <code>bootstrap-grid.css</code> yourself, and place it in your
+            <code>assets/</code> directory, as described in the
+            <a href="https://dash.plot.ly/external-resources">
+              Plotly Dash documentation
+            </a>.
+          </p>
+          <p>
+            With just the grid CSS, you should only expect the layout components
+            <code>Container</code>, <code>Row</code> and <code>Col</code> to
+            work properly. Other components require additional classes and styles
+            that are not included in the Bootstrap grid stylesheet.
+          </p>
           <h2 class="section-header mt-5">Customising the stylesheet</h2>
           <hr />
           <p>
@@ -145,9 +171,7 @@ if __name__ == "__main__":
             with the <code>external_stylesheets</code> argument of the
             <code>Dash</code> constructor:
           </p>
-          <pre><code class="language-python">external_stylesheets = [dbc.themes.CERULEAN]
-
-app = dash.Dash(__name__, external_stylesheets=external_stylesheets)</code></pre>
+          <pre><code class="language-python">app = dash.Dash(__name__, external_stylesheets=[dbc.themes.CERULEAN])</code></pre>
           <p>
             You can also download the base CSS from <a
             href="https://github.com/thomaspark/bootswatch/tree/master/dist/">GitHub</a>,


### PR DESCRIPTION
Sometimes you might like to use Bootstrap just for its layout / grid components without modifying the typography, colours, or including extra style classes. This PR adds a CDN link for the bootstrap grid css to the `themes` module to allow users easily include only the CSS required for creating grid layouts.

I am undecided how best to document this at the moment.