### PR TITLE
Add simplified landing page for PyPI without images

### DIFF
--- a/landing-page.md
+++ b/landing-page.md
@@ -1,0 +1,37 @@
+# dash-bootstrap-components
+
+[Plotly Dash][dash-homepage] is great! However, creating the initial
+layout can create a lot of boilerplate. *dash-bootstrap-components*
+reduces this boilerplate by providing standard layouts and high-level
+components.
+
+*dash-bootstrap-components* provides [Bootstrap][bootstrap-homepage]
+components. It is built on top of [reactstrap][reactstrap-homepage].
+
+## Installation
+
+*dash-bootstrap-components* is hosted on PyPI, and can be installed by
+running
+
+```
+pip install dash-bootstrap-components
+```
+
+## Documentation
+
+Head over to the [*documentation*][docs-homepage] for tutorials and
+the API reference.
+
+## Contributing
+
+The source code for *dash-bootstrap-components* is available
+[on GitHub][dbc-repo]. If you find a bug or something is unclear, we encourage
+you to raise an issue. We also welcome contributions, to contribute, fork the
+repository and open a [pull request][dbc-pulls].
+
+[dash-homepage]: https://dash.plot.ly/
+[bootstrap-homepage]: https://getbootstrap.com/
+[dbc-repo]: https://github.com/ASIDataScience/dash-bootstrap-components
+[reactstrap-homepage]: https://reactstrap.github.io/
+[docs-homepage]: https://dash-bootstrap-components.opensource.asidatascience.com
+[dbc-pulls]: https://github.com/ASIDataScience/dash-bootstrap-components/pulls

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def _get_version():
 
 
 def _get_long_description():
-    with open(os.path.join(HERE, "README.md")) as f:
+    with open(os.path.join(HERE, "landing-page.md")) as f:
         return f.read()
 
 


### PR DESCRIPTION
This PR adds a custom (and simple) landing page for PyPI to address the issue of images from the readme not being rendered on PyPI, as logged in issue #95.

I made a prerelease to test the changes, which are viewable [here](https://pypi.org/project/dash-bootstrap-components/0.2.6a3/)