### PR TITLE
Add missing file to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include dash_bootstrap_components/_components/dash_bootstrap_components.min.js
 include dash_bootstrap_components/_components/metadata.json
+include landing-page.md


### PR DESCRIPTION
Without `landing-page.md`, `setup.py` cannot be run by Python. This means `landing-page.md` should be included in the manifest, otherwise pip cannot install dash-bootstrap-components.