### PR TITLE
Add task to push documentation to Heroku

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -92,7 +92,7 @@ def documentation(ctx):
     help={
         "version": "Version number to finalize. Must be "
         "the same version number that was used in the release."
-    }
+    },
 )
 def postrelease(ctx, version):
     """
@@ -173,7 +173,8 @@ def set_documentation_version(version):
         docs_requirements = f.readlines()
     for iline, line in enumerate(docs_requirements):
         if "dash_bootstrap_components" in line:
-            docs_requirements[iline] = f"dash_bootstrap_components=={version}\n"
+            updated_line = f"dash_bootstrap_components=={version}\n"
+            docs_requirements[iline] = updated_line
     with open(docs_requirements_path, "w") as f:
         f.writelines(docs_requirements)
 

--- a/tasks.py
+++ b/tasks.py
@@ -102,6 +102,15 @@ def postrelease(ctx, version):
     run("git push origin master")
 
 
+@task
+def documentation(ctx):
+    """
+    Push documentation to Heroku
+    """
+    info("Pushing documentation to Heroku")
+    run("git subtree push --prefix docs/ heroku master")
+
+
 def build_publish(version):
     info("Cleaning")
     clean()

--- a/tasks.py
+++ b/tasks.py
@@ -52,6 +52,7 @@ def release(ctx, version):
     """
     check_prerequisites()
     info(f"Releasing version {version} as full release")
+    set_documentation_version(version)
     release_notes_lines = get_release_notes(version)
 
     if release_notes_lines is None:
@@ -162,6 +163,18 @@ def set_jsversion(version):
             package_json[iline] = f'  "version": "{version}",\n'
     with open(package_json_path, "w") as f:
         f.writelines(package_json)
+
+
+def set_documentation_version(version):
+    version = normalize_version(version)
+    docs_requirements_path = HERE / "docs" / "requirements.txt"
+    with docs_requirements_path.open() as f:
+        docs_requirements = f.readlines()
+    for iline, line in enumerate(docs_requirements):
+        if "dash_bootstrap_components" in line:
+            docs_requirements[iline] = f"dash_bootstrap_components=={version}\n"
+    with open(docs_requirements_path, "w") as f:
+        f.writelines(docs_requirements)
 
 
 def get_release_notes(version):

--- a/tasks.py
+++ b/tasks.py
@@ -78,7 +78,17 @@ def release(ctx, version):
     run("git push origin master --tags")
 
 
+@task
+def documentation(ctx):
+    """
+    Push documentation to Heroku
+    """
+    info("Pushing documentation to Heroku")
+    run("git subtree push --prefix docs/ heroku master")
+
+
 @task(
+    documentation,
     help={
         "version": "Version number to finalize. Must be "
         "the same version number that was used in the release."
@@ -101,15 +111,6 @@ def postrelease(ctx, version):
     )
     run('git commit -m "Back to dev"')
     run("git push origin master")
-
-
-@task
-def documentation(ctx):
-    """
-    Push documentation to Heroku
-    """
-    info("Pushing documentation to Heroku")
-    run("git subtree push --prefix docs/ heroku master")
 
 
 def build_publish(version):


### PR DESCRIPTION
This adds a `documentation` task that pushes current master to Heroku. You can now just run:

```
inv documentation
```

I tested this when upgrading the documentation to 0.2.6.