### PR TITLE
Add Textarea component

### DIFF
--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -13,6 +13,7 @@ from ...metadata import get_component_metadata
 from .radio_check import inputs as input_radio_check
 from .size import inputs as input_size
 from .text_label import text_input as input_text_label
+from .textarea import textareas as input_textarea
 from .validation import inputs as input_validation
 
 HERE = Path(__file__).parent
@@ -22,6 +23,7 @@ input_text_label_source = (HERE / "text_label.py").read_text()
 input_size_source = (HERE / "size.py").read_text()
 input_validation_source = (HERE / "validation.py").read_text()
 input_radio_check_source = (HERE / "radio_check.py").read_text()
+input_textarea_source = (HERE / "textarea.py").read_text()
 
 
 def get_content(app):
@@ -85,6 +87,17 @@ def get_content(app):
         ),
         ExampleContainer(input_validation),
         HighlightedSource(input_validation_source),
+        html.H4("Textarea"),
+        html.P(
+            dcc.Markdown(
+                "The `Textarea` component works like the "
+                "`dash-core-components` analogue, but accepts the additional "
+                "arguments `valid`, `invalid`, and `bs_size` much like "
+                "`Input`."
+            )
+        ),
+        ExampleContainer(input_textarea),
+        HighlightedSource(input_textarea_source),
         html.H4("RadioItems and Checklist"),
         html.P(
             dcc.Markdown(
@@ -101,6 +114,10 @@ def get_content(app):
         ApiDoc(
             get_component_metadata("src/components/input/Input.js"),
             component_name="Input",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/input/Textarea.js"),
+            component_name="Textarea",
         ),
         ApiDoc(
             get_component_metadata("src/components/input/RadioItems.js"),

--- a/docs/components_page/components/input/textarea.py
+++ b/docs/components_page/components/input/textarea.py
@@ -1,0 +1,17 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+textareas = html.Div(
+    [
+        dbc.Textarea(className="mb-3", placeholder="A Textarea"),
+        dbc.Textarea(
+            valid=True,
+            bs_size="sm",
+            className="mb-3",
+            placeholder="A small, valid Textarea",
+        ),
+        dbc.Textarea(
+            invalid=True, bs_size="lg", placeholder="A large, invalid Textarea"
+        ),
+    ]
+)

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -103,7 +103,6 @@ Input.propTypes = {
   type: PropTypes.oneOf([
     // Only allowing the input types with wide browser compatability
     'text',
-    'textarea',
     'number',
     'password',
     'email',

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -1,0 +1,239 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {omit} from 'ramda';
+import classNames from 'classnames';
+
+/**
+ * A basic HTML textarea for entering multiline text based on the corresponding
+ * component in dash-core-components
+ *
+ */
+export default class Textarea extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {value: props.value};
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({value: nextProps.value});
+  }
+
+  render() {
+    const {
+      fireEvent,
+      setProps,
+      className,
+      invalid,
+      valid,
+      bs_size
+    } = this.props;
+    const {value} = this.state;
+
+    const classes = classNames(
+      className,
+      invalid && 'is-invalid',
+      valid && 'is-valid',
+      bs_size ? `form-control-${bs_size}` : false,
+      'form-control'
+    );
+
+    return (
+      <textarea
+        value={value}
+        className={classes}
+        onChange={e => {
+          this.setState({value: e.target.value});
+          if (setProps) {
+            setProps({value: e.target.value});
+          }
+          if (fireEvent) {
+            fireEvent({event: 'change'});
+          }
+        }}
+        onBlur={() => {
+          if (fireEvent) {
+            fireEvent({event: 'blur'});
+          }
+        }}
+        onClick={() => {
+          if (fireEvent) {
+            fireEvent({event: 'click'});
+          }
+        }}
+        {...omit(
+          [
+            'fireEvent',
+            'setProps',
+            'value',
+            'valid',
+            'invalid',
+            'bs_size',
+            'className'
+          ],
+          this.props
+        )}
+      />
+    );
+  }
+}
+
+Textarea.propTypes = {
+  /**
+   * The ID of this component, used to identify dash components
+   * in callbacks. The ID needs to be unique across all of the
+   * components in an app.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The value of the textarea
+   */
+  value: PropTypes.string,
+
+  /**
+   * The element should be automatically focused after the page loaded.
+   */
+  autoFocus: PropTypes.string,
+
+  /**
+   * Defines the number of columns in a textarea.
+   */
+  cols: PropTypes.string,
+
+  /**
+   * Indicates whether the user can interact with the element.
+   */
+  disabled: PropTypes.string,
+
+  /**
+   * Indicates the form that is the owner of the element.
+   */
+  form: PropTypes.string,
+
+  /**
+   * Defines the maximum number of characters allowed in the element.
+   */
+  maxLength: PropTypes.string,
+
+  /**
+   * Defines the minimum number of characters allowed in the element.
+   */
+  minLength: PropTypes.string,
+
+  /**
+   * Name of the element. For example used by the server to identify the fields in form submits.
+   */
+  name: PropTypes.string,
+
+  /**
+   * Provides a hint to the user of what can be entered in the field.
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * Indicates whether the element can be edited.
+   */
+  readOnly: PropTypes.string,
+
+  /**
+   * Indicates whether this element is required to fill out or not.
+   */
+  required: PropTypes.string,
+
+  /**
+   * Defines the number of rows in a text area.
+   */
+  rows: PropTypes.string,
+
+  /**
+   * Indicates whether the text should be wrapped.
+   */
+  wrap: PropTypes.string,
+
+  /**
+   * Defines a keyboard shortcut to activate or add focus to the element.
+   */
+  accessKey: PropTypes.string,
+
+  /**
+   * Often used with CSS to style elements with common properties.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Indicates whether the element's content is editable.
+   */
+  contentEditable: PropTypes.string,
+
+  /**
+   * Defines the ID of a <menu> element which will serve as the element's context menu.
+   */
+  contextMenu: PropTypes.string,
+
+  /**
+   * Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+   */
+  dir: PropTypes.string,
+
+  /**
+   * Defines whether the element can be dragged.
+   */
+  draggable: PropTypes.string,
+
+  /**
+   * Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+   */
+  hidden: PropTypes.string,
+
+  /**
+   * Defines the language used in the element.
+   */
+  lang: PropTypes.string,
+
+  /**
+   * Indicates whether spell checking is allowed for the element.
+   */
+  spellCheck: PropTypes.string,
+
+  /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
+   * Overrides the browser's default tab order and follows the one specified instead.
+   */
+  tabIndex: PropTypes.string,
+
+  /**
+   * Text to be displayed in a tooltip when hovering over the element.
+   */
+  title: PropTypes.string,
+
+  /**
+   * Dash-assigned callback that gets fired when the value changes.
+   */
+  setProps: PropTypes.func,
+
+  /**
+   * A callback for firing events to dash.
+   */
+  fireEvent: PropTypes.func,
+
+  /**
+   * Set the size of the Textarea, valid options are 'sm', 'md', or 'lg'
+   */
+  bs_size: PropTypes.string,
+
+  /**
+   * Apply valid style to the Textarea
+   */
+  valid: PropTypes.bool,
+
+  /**
+   * Apply invalid style to the Textarea
+   */
+  invalid: PropTypes.bool,
+
+  dashEvents: PropTypes.oneOf(['click', 'blur', 'change'])
+};

--- a/src/index.js
+++ b/src/index.js
@@ -57,4 +57,5 @@ export {default as Row} from './components/layout/Row';
 export {default as Tab} from './components/tabs/Tab';
 export {default as Tabs} from './components/tabs/Tabs';
 export {default as Table} from './components/Table';
+export {default as Textarea} from './components/input/Textarea';
 export {default as Tooltip} from './components/Tooltip';


### PR DESCRIPTION
This PR adds a `Textarea` component that, much like the `Input` component, behaves like its analogue in `dash-core-components`, but adds Bootstrap styling, thereby addressing #116.

It also adds some basic documentation to the Input section of the docs page.