### PR TITLE
Add the documentation version change to git when releasing

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -70,6 +70,7 @@ def release(ctx, version):
     info("Committing version changes")
     run(
         "git add package.json package-lock.json "
+        "docs/requirements.txt "
         "dash_bootstrap_components/_version.py"
     )
     run(f'git commit -m "Bump version to {version}"')


### PR DESCRIPTION
Prior to this PR, we bumped the version of dash-bootstrap-components in docs/requirements.txt, but this was never added to the git index, so it was never pushed as part of the commit marking the release. Now fixed.