### PR TITLE
Bump bootstrap version to 4.2.1

### DIFF
--- a/dash_bootstrap_components/themes.py
+++ b/dash_bootstrap_components/themes.py
@@ -1,11 +1,10 @@
 BOOTSTRAP = (
-    "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+    "https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
 )
 
-# Grid only
-GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap-grid.min.css"  # noqa
+GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap-grid.min.css"  # noqa
 
-_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.1.3/"
+_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.2.1/"
 
 CERULEAN = _BOOTSWATCH_BASE + "cerulean/bootstrap.min.css"
 COSMO = _BOOTSWATCH_BASE + "cosmo/bootstrap.min.css"

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
 </head>
 
 <body>

--- a/docs/app.py
+++ b/docs/app.py
@@ -7,9 +7,8 @@ from dash.dependencies import Input, Output
 from components_page import ComponentsPage
 from demos.demo_layout import DemoLayoutPage
 
-BOOTSTRAP_CSS = (
-    "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-)
+BOOTSTRAP_CSS = dbc.themes.BOOTSTRAP
+
 HIGHLIGHT_JS_CSS = (
     "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.13.1/"
     "build/styles/monokai-sublime.min.css"

--- a/docs/demos/demo_layout.py
+++ b/docs/demos/demo_layout.py
@@ -68,12 +68,6 @@ class DemoLayoutPage:
 
 
 if __name__ == "__main__":
-    app = Dash(
-        __name__,
-        external_stylesheets=[
-            "https://stackpath.bootstrapcdn.com/bootstrap/"
-            "4.1.3/css/bootstrap.min.css"
-        ],
-    )
+    app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
     app.layout = _layout
     app.run_server(port=8888, debug=True)

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.13.1/build/styles/monokai-sublime.min.css">
     <link rel="stylesheet" href="/assets/docs.css" />
     <title>Dash Bootstrap Components</title>


### PR DESCRIPTION
This PR updates the CDN links in the `themes` module to use Bootstrap version 4.2.1.

Though we can't yet take advantage of the new components, there are some new utility CSS classes available which I think are useful to have access to.

Here's a link to the [bootstrap release notes](https://github.com/twbs/bootstrap/releases/tag/v4.2.0) for reference (for version 4.2.0, it was bumped to 4.2.1 just to republish on npm)