### PR TITLE
Document Nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dash_bootstrap_components/metadata.json
 *.pyc
 dist
 changelog.tmp
+dash_bootstrap_components/_components/

--- a/docs/components_page/components/nav/__init__.py
+++ b/docs/components_page/components/nav/__init__.py
@@ -107,6 +107,14 @@ def get_content(app):
         ),
         ExampleContainer(nav_pill),
         HighlightedSource(nav_pill_source),
+        html.H4("Tabs"),
+        html.P(
+            dcc.Markdown(
+                "Bootstrap also lets you apply tab styling to navs, check out "
+                "our self-contained `Tabs` component "
+                "[here](/l/components/tabs)."
+            )
+        ),
         ApiDoc(
             get_component_metadata("src/components/nav/Nav.js"),
             component_name="Nav",

--- a/docs/components_page/components/nav/__init__.py
+++ b/docs/components_page/components/nav/__init__.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+import dash_core_components as dcc
+import dash_html_components as html
+
+from ...api_doc import ApiDoc
+from ...helpers import (
+    ExampleContainer,
+    HighlightedSource,
+    load_source_with_environment,
+)
+from ...metadata import get_component_metadata
+from .fill import navs as nav_fill
+from .link_based import nav as nav_link_based
+from .pill import nav as nav_pill
+from .simple import nav as nav_simple
+from .vertical import nav as nav_vertical
+
+HERE = Path(__file__).parent
+
+nav_simple_source = (HERE / "simple.py").read_text()
+nav_link_based_source = (HERE / "link_based.py").read_text()
+navlink_source = (HERE / "navlink.py").read_text()
+nav_fill_source = (HERE / "fill.py").read_text()
+nav_vertical_source = (HERE / "vertical.py").read_text()
+nav_pill_source = (HERE / "pill.py").read_text()
+
+
+def get_content(app):
+    return [
+        html.H2("Navs", className="display-4"),
+        html.P(
+            dcc.Markdown(
+                "Documentation and examples for how to use Bootstrap's "
+                "navigation components with *dash-bootstrap-components*."
+            ),
+            className="lead",
+        ),
+        html.H4("Base nav"),
+        html.P(
+            dcc.Markdown(
+                "Navigation is built up using `Nav`, `NavItem`, `NavLink` and "
+                "`DropdownMenu`. Use `nav=True` when using `DropdownMenu` "
+                "inside a `Nav` for consistent styling with `NavItem` and "
+                "`NavLink`."
+            )
+        ),
+        ExampleContainer(nav_simple),
+        HighlightedSource(nav_simple_source),
+        html.P(
+            dcc.Markdown(
+                "It is only necessary to wrap `NavLink` with `NavItem` if you "
+                "wish to use the `fill` or `justified` keyword arguments "
+                "detailed below. If you're not using those features you can "
+                "simplify your layout by just passing `NavLink` directly as "
+                "children of `Nav`."
+            )
+        ),
+        ExampleContainer(nav_link_based),
+        HighlightedSource(nav_link_based_source),
+        html.H4("Using NavLink"),
+        html.P(
+            dcc.Markdown(
+                "The `NavLink` component can be used like "
+                "`dash_core_components.Link`, as a regular hyperlink, or "
+                "as a button by attaching a callback to the `n_clicks` prop. "
+                "`NavLink` will behave like `dcc.Link` by default if we "
+                "assign a relative path to `href`, and like a hyperlink if we "
+                "assign an absolute path. This can be overridden using the "
+                "`external_link` argument. This is useful, for example, when "
+                "accessing routes on the underlying flask server."
+            )
+        ),
+        ExampleContainer(
+            load_source_with_environment(navlink_source, "nav", {"app": app})
+        ),
+        HighlightedSource(navlink_source),
+        html.H4("Horizontal alignment"),
+        html.P(
+            dcc.Markdown(
+                "Use `fill=True` to force navigation items to expand to fill "
+                "available horizontal space. Use `justified=True` to fill "
+                "available horizontal space, with each item having equal "
+                "width."
+            )
+        ),
+        ExampleContainer(nav_fill),
+        HighlightedSource(nav_fill_source),
+        html.H4("Vertical stacking"),
+        html.P(
+            dcc.Markdown(
+                "Use the `vertical` argument to stack navigation items. You "
+                "can pass either a Boolean, or one of the Bootstrap "
+                "breakpoints e.g. `'sm'`, `'lg'`. The example below is "
+                "vertical on screens larger than the medium breakpoint, and "
+                "horizontal on smaller screens."
+            )
+        ),
+        ExampleContainer(nav_vertical),
+        HighlightedSource(nav_vertical_source),
+        html.H4("Pills"),
+        html.P(
+            dcc.Markdown(
+                "Use the `pills` argument to indicate active state with pill "
+                "styled nav items."
+            )
+        ),
+        ExampleContainer(nav_pill),
+        HighlightedSource(nav_pill_source),
+        ApiDoc(
+            get_component_metadata("src/components/nav/Nav.js"),
+            component_name="Nav",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/nav/NavItem.js"),
+            component_name="NavItem",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/nav/NavLink.js"),
+            component_name="NavLink",
+        ),
+    ]

--- a/docs/components_page/components/nav/fill.py
+++ b/docs/components_page/components/nav/fill.py
@@ -1,0 +1,20 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+nav1 = dbc.Nav(
+    [
+        dbc.NavItem(dbc.NavLink("A link", href="#")),
+        dbc.NavItem(dbc.NavLink("Another link with a longer label", href="#")),
+    ],
+    fill=True,
+)
+
+nav2 = dbc.Nav(
+    [
+        dbc.NavItem(dbc.NavLink("A link", href="#")),
+        dbc.NavItem(dbc.NavLink("Another link with a longer label", href="#")),
+    ],
+    justified=True,
+)
+
+navs = html.Div([nav1, html.Hr(), nav2])

--- a/docs/components_page/components/nav/link_based.py
+++ b/docs/components_page/components/nav/link_based.py
@@ -1,0 +1,10 @@
+import dash_bootstrap_components as dbc
+
+nav = dbc.Nav(
+    [
+        dbc.NavLink("Active", active=True, href="#"),
+        dbc.NavLink("A link", href="#"),
+        dbc.NavLink("Another link", href="#"),
+        dbc.NavLink("Disabled", disabled=True, href="#"),
+    ]
+)

--- a/docs/components_page/components/nav/navlink.py
+++ b/docs/components_page/components/nav/navlink.py
@@ -1,0 +1,29 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+nav = html.Div(
+    [
+        dbc.Nav(
+            [
+                dbc.NavLink("Internal link", href="/l/components/nav"),
+                dbc.NavLink("External link", href="https://github.com"),
+                dbc.NavLink(
+                    "External relative",
+                    href="/l/components/nav",
+                    external_link=True,
+                ),
+                dbc.NavLink("Button", id="button-link", n_clicks=0),
+            ]
+        ),
+        html.Br(),
+        html.P(id="button-clicks"),
+    ]
+)
+
+
+@app.callback(
+    Output("button-clicks", "children"), [Input("button-link", "n_clicks")]
+)
+def show_clicks(n):
+    return "Button clicked {} times".format(n)

--- a/docs/components_page/components/nav/pill.py
+++ b/docs/components_page/components/nav/pill.py
@@ -1,0 +1,11 @@
+import dash_bootstrap_components as dbc
+
+nav = dbc.Nav(
+    [
+        dbc.NavItem(dbc.NavLink("Active", active=True, href="#")),
+        dbc.NavItem(dbc.NavLink("A link", href="#")),
+        dbc.NavItem(dbc.NavLink("Another link", href="#")),
+        dbc.NavItem(dbc.NavLink("Disabled", disabled=True, href="#")),
+    ],
+    pills=True,
+)

--- a/docs/components_page/components/nav/simple.py
+++ b/docs/components_page/components/nav/simple.py
@@ -1,0 +1,15 @@
+import dash_bootstrap_components as dbc
+
+nav = dbc.Nav(
+    [
+        dbc.NavItem(dbc.NavLink("Active", active=True, href="#")),
+        dbc.NavItem(dbc.NavLink("A link", href="#")),
+        dbc.NavItem(dbc.NavLink("Another link", href="#")),
+        dbc.NavItem(dbc.NavLink("Disabled", disabled=True, href="#")),
+        dbc.DropdownMenu(
+            [dbc.DropdownMenuItem("Item 1"), dbc.DropdownMenuItem("Item 2")],
+            label="Dropdown",
+            nav=True,
+        ),
+    ]
+)

--- a/docs/components_page/components/nav/vertical.py
+++ b/docs/components_page/components/nav/vertical.py
@@ -1,0 +1,11 @@
+import dash_bootstrap_components as dbc
+
+nav = dbc.Nav(
+    [
+        dbc.NavItem(dbc.NavLink("Active", active=True, href="#")),
+        dbc.NavItem(dbc.NavLink("A link", href="#")),
+        dbc.NavItem(dbc.NavLink("Another link", href="#")),
+        dbc.NavItem(dbc.NavLink("Disabled", disabled=True, href="#")),
+    ],
+    vertical="md",
+)

--- a/docs/components_page/components/navbar/__init__.py
+++ b/docs/components_page/components/navbar/__init__.py
@@ -58,7 +58,9 @@ def get_content(app):
                 "navbar you can use the `Navbar` component. This gives you "
                 "full control over the children, but you will have to write "
                 "your own callbacks to achieve things like the toggle "
-                "behaviour on small screens."
+                "behaviour on small screens. We recommend using a `Nav` "
+                "component to wrap the navigation items, check the "
+                "[docs here](/l/components/nav)."
             )
         ),
         html.P(

--- a/docs/components_page/components/tabs/__init__.py
+++ b/docs/components_page/components/tabs/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import dash_core_components as dcc
 import dash_html_components as html
 
 from ...api_doc import ApiDoc
@@ -16,24 +17,39 @@ HERE = Path(__file__).parent
 
 tabs_simple_source = (HERE / "simple.py").read_text()
 tabs_active_source = (HERE / "active_tab.py").read_text()
-
-active_tab_blurb = html.P(
-    [
-        "You can also use the ",
-        html.Code("active_tab"),
-        " prop of ",
-        html.Code("Tabs"),
-        " in your callbacks to switch between tabs.",
-    ]
-)
+tabs_card_source = (HERE / "card.py").read_text()
 
 
 def get_content(app):
     return [
-        html.H2("Tabs"),
+        html.H2("Tabs", className="display-4"),
+        html.P(
+            "A self-contained tabs component with Bootstrap styles.",
+            className="lead",
+        ),
+        html.H4("Tabs as children"),
+        html.P(
+            dcc.Markdown(
+                "The easiest way to use `Tabs` is to pass it one or more "
+                "`Tab` components as children. Use the `label` argument to "
+                "specify the label in the tab. `Tabs` will automatically "
+                "switch between tabs for you by displaying and hiding the "
+                "content of each `Tab` below the tab pane."
+            )
+        ),
         ExampleContainer(tabs_simple),
         HighlightedSource(tabs_simple_source),
-        active_tab_blurb,
+        html.H4("Tabs with callback"),
+        html.P(
+            dcc.Markdown(
+                "You can also use the `active_tab` prop of `Tabs` in a "
+                "callback to switch between tabs. This is useful if you want "
+                "to have content recalculated / recomputed when you switch "
+                "tabs, or if you want to have the active tab affect something "
+                "on the page that isn't positioned directly below the tab "
+                "pane."
+            )
+        ),
         ExampleContainer(
             load_source_with_environment(
                 tabs_active_source,
@@ -46,6 +62,21 @@ def get_content(app):
             )
         ),
         HighlightedSource(tabs_active_source),
+        html.H4("Tabs in Cards"),
+        html.P(
+            dcc.Markdown(
+                "Use `card=True` when placing your `Tabs` inside a "
+                "`CardHeader`. You must use a callback to insert the tab "
+                "content into the card body rather than relying on the tabs "
+                "as children approach outlined above."
+            )
+        ),
+        ExampleContainer(
+            load_source_with_environment(
+                tabs_card_source, "card", {"app": app}
+            )
+        ),
+        HighlightedSource(tabs_card_source),
         ApiDoc(
             get_component_metadata("src/components/tabs/Tabs.js"),
             component_name="Tabs",

--- a/docs/components_page/components/tabs/card.py
+++ b/docs/components_page/components/tabs/card.py
@@ -1,0 +1,26 @@
+import dash_bootstrap_components as dbc
+from dash.dependencies import Input, Output
+
+card = dbc.Card(
+    [
+        dbc.CardHeader(
+            dbc.Tabs(
+                [
+                    dbc.Tab(label="Tab 1", tab_id="tab-1"),
+                    dbc.Tab(label="Tab 2", tab_id="tab-2"),
+                ],
+                id="card-tabs",
+                card=True,
+                active_tab="tab-1",
+            )
+        ),
+        dbc.CardBody(dbc.CardText(id="card-content")),
+    ]
+)
+
+
+@app.callback(
+    Output("card-content", "children"), [Input("card-tabs", "active_tab")]
+)
+def tab_content(active_tab):
+    return "This is tab {}".format(active_tab)

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -15,6 +15,7 @@ from .components.input_group import get_content as get_input_group_content
 from .components.jumbotron import content as jumbotron_content
 from .components.layout import content as layout_content
 from .components.list_group import get_content as get_list_group_content
+from .components.nav import get_content as get_nav_content
 from .components.navbar import get_content as get_navbar_content
 from .components.popover import get_content as get_popover_content
 from .components.progress import get_content as get_progress_content
@@ -51,6 +52,7 @@ sidebar_entries = [
     SidebarEntry("jumbotron", "Jumbotron"),
     SidebarEntry("layout", "Layout"),
     SidebarEntry("list_group", "List Group"),
+    SidebarEntry("nav", "Navs"),
     SidebarEntry("navbar", "Navbar"),
     SidebarEntry("popover", "Popover"),
     SidebarEntry("progress", "Progress"),
@@ -87,6 +89,7 @@ class ComponentsPage:
             "jumbotron": jumbotron_content,
             "layout": layout_content,
             "list_group": get_list_group_content(self._app),
+            "nav": get_nav_content(self._app),
             "navbar": get_navbar_content(self._app),
             "popover": get_popover_content(self._app),
             "progress": get_progress_content(self._app),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.black]
 line-length = 79
+exclude = "dash_bootstrap_components/_components"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,8 @@ exclude =
     docs/components_page/components/popover/popover.py,
     docs/components_page/components/progress/progress.py,
     docs/components_page/components/table/kwargs.py,
-    docs/components_page/components/tabs/active_tab.py
+    docs/components_page/components/tabs/active_tab.py,
+    docs/components_page/components/tabs/card.py,
 ignore = E203, W503
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 exclude =
     node_modules,
+    dash_bootstrap_components/_components,
     docs/components_page/components/button/usage.py,
     docs/components_page/components/collapse/collapse.py,
     docs/components_page/components/fade/fade.py,
@@ -9,6 +10,7 @@ exclude =
     docs/components_page/components/input_group/button.py,
     docs/components_page/components/input_group/dropdown.py,
     docs/components_page/components/list_group/links.py,
+    docs/components_page/components/nav/navlink.py,
     docs/components_page/components/navbar/navbar.py,
     docs/components_page/components/popover/popover.py,
     docs/components_page/components/progress/progress.py,

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -3,21 +3,46 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Link from '../../private/Link';
 
-const NavLink = ({children, className, active, ...otherProps}) => {
-  const classes = classNames(className, 'nav-link', {
-    active,
-    disabled: otherProps.disabled
-  });
-  return (
-    <Link className={classes} {...otherProps}>
-      {children}
-    </Link>
-  );
-};
+
+class NavLink extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.incrementClicks = this.incrementClicks.bind(this);
+  }
+
+  incrementClicks() {
+    if (!this.props.disabled && this.props.setProps) {
+      this.props.setProps({
+        n_clicks: this.props.n_clicks + 1,
+        n_clicks_timestamp: Date.now()
+      });
+    }
+  }
+
+  render() {
+    const {children, className, active, ...otherProps} = this.props;
+    const classes = classNames(className, 'nav-link', {
+      active,
+      disabled: otherProps.disabled
+    });
+    return (
+      <Link
+        className={classes}
+        preOnClick={this.incrementClicks}
+        {...otherProps}
+      >
+        {children}
+      </Link>
+    );
+  }
+}
 
 NavLink.defaultProps = {
   active: false,
-  disabled: false
+  disabled: false,
+  n_clicks: 0,
+  n_clicks_timestamp: -1
 };
 
 NavLink.propTypes = {
@@ -57,6 +82,29 @@ NavLink.propTypes = {
    * Disable the link
    */
   disabled: PropTypes.bool,
+
+  /**
+   * If true, the browser will treat this as an external link,
+   * forcing a page refresh at the new location. If false,
+   * this just changes the location without triggering a page
+   * refresh. Use this if you are observing dcc.Location, for
+   * instance. Defaults to true for absolute URLs and false
+   * otherwise.
+   */
+  external_link: PropTypes.bool,
+
+  /**
+   * An integer that represents the number of times
+   * that this element has been clicked on.
+   */
+  n_clicks: PropTypes.number,
+
+  /**
+   * An integer that represents the time (in ms since 1970)
+   * at which n_clicks changed. This can be used to tell
+   * which button was changed most recently.
+   */
+  n_clicks_timestamp: PropTypes.number,
 
   dashEvents: PropTypes.oneOf(['click'])
 };

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -84,7 +84,15 @@ class Tabs extends React.Component {
     });
     return (
       <div>
-        <Nav tabs={true}>{links}</Nav>
+        <Nav
+          id={this.props.id}
+          tabs={true}
+          card={this.props.card}
+          className={this.props.className}
+          style={this.props.style}
+        >
+          {links}
+        </Nav>
         <TabContent activeTab={this.state.activeTab}>{tabs}</TabContent>
       </div>
     );
@@ -118,7 +126,12 @@ Tabs.propTypes = {
    * Determine which tab is currently showing. Will be the id of the tab or
    * 'tab-i' where i is the index of the tab (indexed from zero)
    */
-  active_tab: PropTypes.string
+  active_tab: PropTypes.string,
+
+  /**
+   * Set to True to use the card header style for tabs.
+   */
+  card: PropTypes.bool
 };
 
 export default Tabs;


### PR DESCRIPTION
This PR adds documentation for the `Nav` component, primarily motivated by confusion documented in #124. In that issue I outlined the following tasks:

- [x] ~Clarify docstring of `DropdownMenu`~ *(no change here, I decided they were explicit enough)*
- [x] Add page to docs for `Nav`
- [x] Mention `Nav` explicitly in the docs for `Navbar`

In the course of preparing the documentation, guided by both Bootstrap and reactstrap docs, I also did the following:

- Add `external_link` prop to `NavLink` which gets passed to the underlying `Link` component. Previously it was not possible to set this in the Python interface.
- Add `n_clicks` and `n_clicks_timestamp` props to `NavLink` to allow usage as a button in callbacks. Implementation is following that of `DropdownMenuItem`.
- Add `card` prop to `Tabs` to allow use of `Tabs` inside a `CardHeader`, This has also been added to the card documentation.
- Previously the `id`, `className` and `style` props of `Tabs` didn't actually get used by the underlying React component (`id` could still be used correctly in callbacks), I have passed all of these to the `Nav` component that `Tabs` is built from.
- Experimented with a display heading and a lead paragraph on the docs pages for `Nav` and `Tabs`, inspired by the official Bootstrap documentation. If we decide we like it we can roll this out to all the other component pages too in future.

I made prerelease `0.3.1rc1` for testing all of the above.