### PR TITLE
Remove Events

### DIFF
--- a/docs/components_page/api_doc.py
+++ b/docs/components_page/api_doc.py
@@ -1,10 +1,7 @@
-from itertools import chain
-
 import dash_html_components as html
 from dash.development._py_components_generation import (
     filter_props,
     js_to_py_type,
-    parse_events,
     reorder_props,
 )
 
@@ -12,8 +9,7 @@ from dash.development._py_components_generation import (
 def ApiDoc(component_metadata, component_name=None):
     component_props = component_metadata.get("props", {})
     return html.Div(
-        ArgumentsList(component_props, component_name)
-        + EventsList(component_props, component_name),
+        ArgumentsList(component_props, component_name),
         className="api-documentation",
     )
 
@@ -47,25 +43,3 @@ def Argument(argument_name, argument_metadata):
     return html.Li(
         [html.Code(argument_name), html.I(type_string), ": ", description]
     )
-
-
-def EventsList(component_props, component_name):
-    if component_name is not None:
-        heading = f"Available events for {component_name}"
-    else:
-        heading = "Available events"
-    events = parse_events(component_props)
-    if not events:
-        return []
-    else:
-        event_components = [Event(event) for event in events]
-        events_list = list(
-            chain.from_iterable(
-                [(component, " ") for component in event_components]
-            )
-        )
-        return [html.H4(heading, className="mt-5 mb-2")] + events_list
-
-
-def Event(event):
-    return html.Code(event.lstrip("'").rstrip("'"))

--- a/docs/run.py
+++ b/docs/run.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template
 
 from app import App
 
-server = Flask(__name__)
+server = Flask(__name__, static_folder="assets")
 
 
 @server.route("/")

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.13.1/build/styles/monokai-sublime.min.css">
-    <link rel="stylesheet" href="/assets/docs.css" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='docs.css') }}" />
     <title>Dash Bootstrap Components</title>
   </head>
   <body>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -13,7 +13,6 @@ const Button = props => {
             n_clicks_timestamp: Date.now()
           });
         }
-        if (props.fireEvent) props.fireEvent({event: 'click'});
       }}
       {...otherProps}
     >
@@ -99,14 +98,7 @@ Button.propTypes = {
   /**
    * Set outline button style.
    */
-  outline: PropTypes.bool,
-
-  /**
-   * A callback for firing events to dash.
-   */
-  fireEvent: PropTypes.func,
-
-  dashEvents: PropTypes.oneOf(['click'])
+  outline: PropTypes.bool
 };
 
 export default Button;

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -22,7 +22,6 @@ class Checklist extends React.Component {
   render() {
     const {
       className,
-      fireEvent,
       id,
       inputClassName,
       inputStyle,
@@ -58,9 +57,6 @@ class Checklist extends React.Component {
                 this.setState({values: newValues});
                 if (setProps) {
                   setProps({values: newValues});
-                }
-                if (fireEvent) {
-                  fireEvent({event: 'change'});
                 }
               }}
             />
@@ -143,11 +139,6 @@ Checklist.propTypes = {
   labelClassName: PropTypes.string,
 
   /**
-   * Dash-assigned callback that gets fired when the checkbox item gets selected.
-   */
-  fireEvent: PropTypes.func,
-
-  /**
    * Dash-assigned callback that gets fired when the value changes.
    */
   setProps: PropTypes.func,
@@ -155,9 +146,7 @@ Checklist.propTypes = {
   /**
    * Arrange Checklist inline
    */
-  inline: PropTypes.bool,
-
-  dashEvents: PropTypes.oneOf(['change'])
+  inline: PropTypes.bool
 };
 
 Checklist.defaultProps = {

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -67,7 +67,7 @@ export default class DatePickerRange extends React.Component {
     this.propsToState(this.props);
   }
   onDatesChange({startDate: start_date, endDate: end_date}) {
-    const {setProps, fireEvent, updatemode} = this.props;
+    const {setProps, updatemode} = this.props;
     const old_start_date = this.state.start_date;
     const old_end_date = this.state.end_date;
     const newState = {};
@@ -90,10 +90,6 @@ export default class DatePickerRange extends React.Component {
       }
     }
     newState.end_date = end_date;
-
-    if (fireEvent) {
-      fireEvent('change');
-    }
 
     this.setState(newState);
   }
@@ -340,11 +336,6 @@ DatePickerRange.propTypes = {
   setProps: PropTypes.func,
 
   /**
-   * Dash-assigned callback that gets fired when the value changes.
-   */
-  dashEvents: PropTypes.oneOf(['change']),
-
-  /**
    * Determines when the component should update
    * its value. If `bothdates`, then the DatePicker
    * will only trigger its value when the user has
@@ -363,9 +354,7 @@ DatePickerRange.propTypes = {
   /**
    * Set the size of the DatePickerSingle
    */
-  bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
-
-  fireEvent: PropTypes.func
+  bs_size: PropTypes.oneOf(['sm', 'md', 'lg'])
 };
 
 DatePickerRange.defaultProps = {

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -83,14 +83,11 @@ export default class DatePickerSingle extends React.Component {
   }
 
   onDateChange(date) {
-    const {setProps, fireEvent} = this.props;
+    const {setProps} = this.props;
     if (setProps && date !== null) {
       setProps({date: date.format('YYYY-MM-DD')});
     } else {
       this.setState({date});
-    }
-    if (fireEvent) {
-      fireEvent('change');
     }
   }
 
@@ -283,11 +280,6 @@ DatePickerSingle.propTypes = {
   setProps: PropTypes.func,
 
   /**
-   * Dash-assigned callback that gets fired when the value changes.
-   */
-  dashEvents: PropTypes.oneOf(['change']),
-
-  /**
    * Set the size of the DatePickerSingle
    */
   bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
@@ -296,9 +288,7 @@ DatePickerSingle.propTypes = {
    * A list of days to disable in addition to any that fall outside of the range
    * specified by min_date_allowed and max_date_allowed.
    */
-  disabled_days: PropTypes.arrayOf(PropTypes.string),
-
-  fireEvent: PropTypes.func
+  disabled_days: PropTypes.arrayOf(PropTypes.string)
 };
 
 DatePickerSingle.defaultProps = {

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -15,7 +15,6 @@ class Input extends React.Component {
 
   render() {
     const {
-      fireEvent,
       setProps,
       type,
       className,
@@ -50,20 +49,11 @@ class Input extends React.Component {
               setProps({value: e.target.value});
             }
           }
-          if (fireEvent) {
-            fireEvent({event: 'change'});
-          }
-        }}
-        onBlur={() => {
-          if (fireEvent) {
-            fireEvent({event: 'blur'});
-          }
         }}
         className={classes}
         value={value}
         {...omit(
           [
-            'fireEvent',
             'setProps',
             'value',
             'className',

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -21,7 +21,6 @@ class RadioItems extends React.Component {
 
   render() {
     const {
-      fireEvent,
       id,
       className,
       style,
@@ -56,9 +55,6 @@ class RadioItems extends React.Component {
                 this.setState({value: option.value});
                 if (setProps) {
                   setProps({value: option.value});
-                }
-                if (fireEvent) {
-                  fireEvent({event: 'change'});
                 }
               }}
             />
@@ -141,11 +137,6 @@ RadioItems.propTypes = {
   labelClassName: PropTypes.string,
 
   /**
-   * Dash-assigned callback that gets fired when the radio item gets selected.
-   */
-  fireEvent: PropTypes.func,
-
-  /**
    * Dash-assigned callback that gets fired when the value changes.
    */
   setProps: PropTypes.func,
@@ -153,9 +144,7 @@ RadioItems.propTypes = {
   /**
    * Arrange RadioItems inline
    */
-  inline: PropTypes.bool,
-
-  dashEvents: PropTypes.oneOf(['change'])
+  inline: PropTypes.bool
 };
 
 RadioItems.defaultProps = {

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -19,14 +19,7 @@ export default class Textarea extends React.Component {
   }
 
   render() {
-    const {
-      fireEvent,
-      setProps,
-      className,
-      invalid,
-      valid,
-      bs_size
-    } = this.props;
+    const {setProps, className, invalid, valid, bs_size} = this.props;
     const {value} = this.state;
 
     const classes = classNames(
@@ -46,30 +39,9 @@ export default class Textarea extends React.Component {
           if (setProps) {
             setProps({value: e.target.value});
           }
-          if (fireEvent) {
-            fireEvent({event: 'change'});
-          }
-        }}
-        onBlur={() => {
-          if (fireEvent) {
-            fireEvent({event: 'blur'});
-          }
-        }}
-        onClick={() => {
-          if (fireEvent) {
-            fireEvent({event: 'click'});
-          }
         }}
         {...omit(
-          [
-            'fireEvent',
-            'setProps',
-            'value',
-            'valid',
-            'invalid',
-            'bs_size',
-            'className'
-          ],
+          ['setProps', 'value', 'valid', 'invalid', 'bs_size', 'className'],
           this.props
         )}
       />
@@ -216,11 +188,6 @@ Textarea.propTypes = {
   setProps: PropTypes.func,
 
   /**
-   * A callback for firing events to dash.
-   */
-  fireEvent: PropTypes.func,
-
-  /**
    * Set the size of the Textarea, valid options are 'sm', 'md', or 'lg'
    */
   bs_size: PropTypes.string,
@@ -233,7 +200,5 @@ Textarea.propTypes = {
   /**
    * Apply invalid style to the Textarea
    */
-  invalid: PropTypes.bool,
-
-  dashEvents: PropTypes.oneOf(['click', 'blur', 'change'])
+  invalid: PropTypes.bool
 };

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -104,9 +104,7 @@ NavLink.propTypes = {
    * at which n_clicks changed. This can be used to tell
    * which button was changed most recently.
    */
-  n_clicks_timestamp: PropTypes.number,
-
-  dashEvents: PropTypes.oneOf(['click'])
+  n_clicks_timestamp: PropTypes.number
 };
 
 export default NavLink;

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -13,10 +13,6 @@ const NavbarToggler = props => {
             n_clicks_timestamp: Date.now()
           });
         }
-        if (props.fireEvent)
-          props.fireEvent({
-            event: 'click'
-          });
       }}
       {...otherProps}
     >


### PR DESCRIPTION
This PR removes events from *dash-bootstrap-components* as they are [no longer supported by Dash](https://github.com/plotly/dash/issues/531).