### PR TITLE
Improve docstrings

### DIFF
--- a/docs/components_page/components/form/__init__.py
+++ b/docs/components_page/components/form/__init__.py
@@ -57,7 +57,11 @@ def get_content(app):
                 "set the `valid` property. The feedback will display if its "
                 "validity matches the validity of the `Input`. For this to "
                 "work you must wrap your `Input` and `FormFeedback` in a "
-                "`FormGroup` component."
+                "`FormGroup` component. In the below example we create two "
+                "`FormFeedback` components, one valid, one not valid. "
+                "They will appear / disappear automatically as the `valid` "
+                "and `invalid` properties of `Input` are set to `True` / "
+                "`False` respectively."
             )
         ),
         ExampleContainer(

--- a/docs/components_page/components/form/feedback.py
+++ b/docs/components_page/components/form/feedback.py
@@ -9,7 +9,13 @@ email_input = html.Div(
                 dbc.Label("Email"),
                 dbc.Input(id="email-input", type="email", value=""),
                 dbc.FormText("We only accept gmail..."),
-                dbc.FormFeedback(id="email-feedback"),
+                dbc.FormFeedback(
+                    "That looks like a gmail address :-)", valid=True
+                ),
+                dbc.FormFeedback(
+                    "Sorry, we only accept gmail for some reason...",
+                    valid=False,
+                ),
             ]
         )
     ]
@@ -17,25 +23,13 @@ email_input = html.Div(
 
 
 # --- Callbacks --- #
-
-# use the same function to set the `valid` prop of both input and feedback
+@app.callback(Output("email-input", "valid"), [Input("email-input", "value")])
 def check_valid(text):
     if text and text.endswith("@gmail.com"):
         return True
     return False
 
 
-app.callback(
-    Output("email-feedback", "valid"), [Input("email-input", "value")]
-)(check_valid)
-
-app.callback(Output("email-input", "valid"), [Input("email-input", "value")])(
-    check_valid
-)
-
-
-# this callback sets the input style to invalid if something has been typed
-# but it's not right.
 @app.callback(
     Output("email-input", "invalid"), [Input("email-input", "value")]
 )
@@ -43,14 +37,3 @@ def check_invalid(text):
     if text and not text.endswith("@gmail.com"):
         return True
     return False
-
-
-# this callback modifies the feedback text according to whether the input is
-# valid or invalid
-@app.callback(
-    Output("email-feedback", "children"), [Input("email-feedback", "valid")]
-)
-def make_feedback(valid):
-    if valid:
-        return "That looks like a gmail address :-)"
-    return "Sorry, we only accept gmail for some reason..."

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -53,7 +53,8 @@ Alert.propTypes = {
   is_open: PropTypes.bool,
 
   /**
-   * Fade on close.
+   * If True, a fade animation will be applied when `is_open` is toggled. If
+   * False the Alert will simply appear and disappear.
    */
   fade: PropTypes.bool
 };

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -82,7 +82,8 @@ Button.propTypes = {
   active: PropTypes.bool,
 
   /**
-   * Create block button.
+   * Create block level button, one that spans the full width of its parent.
+   * Default: False
    */
   block: PropTypes.bool,
 
@@ -98,12 +99,13 @@ Button.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Button size, options: lg, md, sm.
+   * Button size, options: 'lg', 'md', 'sm'.
    */
   size: PropTypes.string,
 
   /**
-   * Set outline button style.
+   * Set outline button style, which removes background images and colors for a
+   * lightweight style.
    */
   outline: PropTypes.bool
 };

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -21,7 +21,7 @@ ButtonGroup.propTypes = {
   children: PropTypes.node,
 
   /**
-   * Class for the button group
+   * Often used with CSS to style elements with common properties.
    */
   className: PropTypes.string,
 
@@ -33,12 +33,12 @@ ButtonGroup.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Stack buttons vertically
+   * Group buttons vertically.
    */
   vertical: PropTypes.bool,
 
   /**
-   * Size of button group
+   * Size of button group, options: 'sm', 'md', 'lg'.
    */
   size: PropTypes.string
 };

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -42,7 +42,7 @@ Collapse.propTypes = {
   key: PropTypes.string,
 
   /**
-   * HTML tag to use for the card body. Default: div.
+   * HTML tag to use for the collapse contents. Default: div.
    */
   tag: PropTypes.string,
 
@@ -52,7 +52,7 @@ Collapse.propTypes = {
   is_open: PropTypes.bool,
 
   /**
-   * Enable for use in a navbar.
+   * Set to True when using a collapse inside a navbar.
    */
   navbar: PropTypes.bool
 };

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -89,7 +89,7 @@ DropdownMenu.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Label for the toggle.
+   * Label for the DropdownMenu toggle.
    */
   label: PropTypes.string,
 
@@ -118,7 +118,8 @@ DropdownMenu.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Set this to True if the dropdown is inside a nav. Default: False.
+   * Set this to True if the dropdown is inside a nav for styling consistent
+   * with other nav items. Default: False.
    */
   nav: PropTypes.bool,
 

--- a/src/components/DropdownMenuItem.js
+++ b/src/components/DropdownMenuItem.js
@@ -69,12 +69,12 @@ DropdownMenuItem.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Style this as 'active'.
+   * Style this item as 'active'.
    */
   active: PropTypes.bool,
 
   /**
-   * Style this as 'disabled'.
+   * Style this item as 'disabled'.
    */
   disabled: PropTypes.bool,
 

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -114,31 +114,52 @@ Label.propTypes = {
 
   /**
    * Specify label width on extra small screen
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   xs: columnProps,
 
   /**
    * Specify label width on a small screen
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   sm: columnProps,
 
   /**
    * Specify label width on a medium screen
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   md: columnProps,
 
   /**
    * Specify label width on a large screen
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   lg: columnProps,
 
   /**
    * Specify label width on an extra large screen
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   xl: columnProps,
 
   /**
-   * Set vertical alignement of the label, default: `center`
+   * Set vertical alignment of the label, options: 'start', 'center', 'end',
+   * default: 'center'
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
 

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -67,7 +67,7 @@ Popover.propTypes = {
   target: PropTypes.string,
 
   /**
-   * Where to inject the popper DOM node, default body
+   * Where to inject the popper DOM node, default body.
    */
   container: PropTypes.string,
 
@@ -77,17 +77,17 @@ Popover.propTypes = {
   is_open: PropTypes.bool,
 
   /**
-   * Hide popover arrow
+   * Hide popover arrow.
    */
   hide_arrow: PropTypes.bool,
 
   /**
-   * CSS class to apply to the popover
+   * CSS class to apply to the popover.
    */
   innerClassName: PropTypes.string,
 
   /**
-   * Optionally override show/hide delays - defualt {show: 0, hide: 250}
+   * Optionally override show/hide delays - default {show: 0, hide: 250}
    */
   delay: PropTypes.oneOfType([
     PropTypes.shape({show: PropTypes.number, hide: PropTypes.number}),
@@ -95,7 +95,7 @@ Popover.propTypes = {
   ]),
 
   /**
-   * Popover offset
+   * Popover offset.
    */
   offset: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -43,39 +43,44 @@ Table.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
   /**
-   * Specify table size, options: sm, md, lg
+   * Specify table size, options: 'sm', 'md', 'lg'
    */
   size: PropTypes.string,
 
   /**
-   * Set bordered style
+   * Apply the `table-bordered` class which adds borders on all sides of the
+   * table and cells.
    */
   bordered: PropTypes.bool,
 
   /**
-   * Set borderless style
+   * Apply the `table-borderless` class which removes all borders from the
+   * table and cells.
    */
   borderless: PropTypes.bool,
 
   /**
-   * Apply striped style
+   * Apply the `table-striped` class which applies 'zebra striping' to rows in
+   * the table body.
    */
   striped: PropTypes.bool,
 
   /**
-   * set 'dark' style
+   * Apply the `table-dark` class for dark cell backgrounds and light text.
    */
   dark: PropTypes.bool,
 
   /**
-   * Add hover animation
+   * Apply the `table-hover` class which enables a hover state on table rows
+   * within the table body.
    */
   hover: PropTypes.bool,
 
   /**
-   * Allow horizontal scrolling if parent is too small to contain table.
+   * Set to True or one of the breakpoints 'sm', 'md', 'lg', 'xl' to make table
+   * scroll horizontally at lower breakpoints.
    */
-  responsive: PropTypes.bool
+  responsive: PropTypes.oneOf([PropTypes.bool, PropTypes.string])
 };
 
 export default Table;

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -76,7 +76,8 @@ Tooltip.propTypes = {
   target: PropTypes.string,
 
   /**
-   * boundaries for popper, can be scrollParent, window, viewport, or any DOM element
+   * Boundaries for popper, can be scrollParent, window, viewport, or any DOM
+   * element
    */
   boundaries_element: PropTypes.string,
 

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -39,22 +39,23 @@ Card.propTypes = {
 
   /**
    * Card color, options: primary, secondary, success, info, warning, danger,
-   * link. Default is secondary
+   * light, dark. Default is light.
    */
   color: PropTypes.string,
 
   /**
-   * Wrap all children in a CardBody element (basically add some padding)
+   * Apply the `card-body` class to the card, so that there is no need to also
+   * include a CardBody component in the children of this Card. Default: False
    */
   body: PropTypes.bool,
 
   /**
-   * Use outline style.
+   * Apply color styling to just the border of the card.
    */
   outline: PropTypes.bool,
 
   /**
-   * Invert text colours for use with a dark color background.
+   * Invert text colours for use with a darker background.
    */
   inverse: PropTypes.bool
 };

--- a/src/components/card/CardImg.js
+++ b/src/components/card/CardImg.js
@@ -43,12 +43,15 @@ CardImg.propTypes = {
   tag: PropTypes.string,
 
   /**
-   * Place image at top of card (round corners etc.)
+   * Set to True if image is at top of card. This will apply the card-img-top
+   * class which rounds the top corners to match the corners of the card.
    */
   top: PropTypes.bool,
 
   /**
-   * Place image at bottom of card (round corners etc.)
+   * Set to True if image is at bottom of card. This will apply the
+   * card-img-bottom class which rounds the bottom corners to match the corners
+   * of the card.
    */
   bottom: PropTypes.bool,
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -38,7 +38,9 @@ Form.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Create inline form
+   * Use inline=True to apply the `form-inline` class, allowing you to display
+   * a series of labels, form controls, and buttons on a single horizontal row.
+   * Form controls within inline forms vary slightly from their default states.
    */
   inline: PropTypes.bool
 };

--- a/src/components/form/FormFeedback.js
+++ b/src/components/form/FormFeedback.js
@@ -38,12 +38,13 @@ FormFeedback.propTypes = {
   key: PropTypes.string,
 
   /**
-   * ...
+   * If True apply the valid styling to the feedback, else apply invalid
+   * styling.
    */
   valid: PropTypes.bool,
 
   /**
-   * ...
+   * Use styled tooltips to display validation feedback.
    */
   tooltip: PropTypes.bool
 };

--- a/src/components/form/FormGroup.js
+++ b/src/components/form/FormGroup.js
@@ -38,24 +38,26 @@ FormGroup.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Apply row class to FormGroup
+   * Apply row class to FormGroup to allow labels and inputs to be displayed
+   * horizontally in a row.
    */
   row: PropTypes.bool,
 
   /**
-   * Set to true for groups with checkboxes or radio buttons for improved layout
+   * Apply `form-check` class instead of `form-group`. Useful when positioning
+   * labels with checkbox / radio inputs. Usually it will be better to use the
+   * pre-built dbc.Checklist or dbc.RadioItems components.
    */
   check: PropTypes.bool,
 
   /**
-   * Create inline group
+   * If check is True, apply the `form-check-inline` class in addition to
+   * `form-check`. If you want to make an inline list of checkboxes / radios
+   * we recommend using either dbc.Checklist or dbc.RadioItems with inline=True
+   *
+   * This prop has no effect if check=False.
    */
-  inline: PropTypes.bool,
-
-  /**
-   * Apply disabled CSS class to form group
-   */
-  disabled: PropTypes.bool
+  inline: PropTypes.bool
 };
 
 export default FormGroup;

--- a/src/components/form/FormText.js
+++ b/src/components/form/FormText.js
@@ -38,11 +38,6 @@ FormText.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Create inline form
-   */
-  inline: PropTypes.bool,
-
-  /**
    * Text color, options: primary, secondary, success, warning, danger, info,
    * muted, light, dark, body, white, black-50, white-50.
    */

--- a/src/components/input/DatePickerRange.js
+++ b/src/components/input/DatePickerRange.js
@@ -362,7 +362,8 @@ DatePickerRange.propTypes = {
   disabled_days: PropTypes.arrayOf(PropTypes.string),
 
   /**
-   * Set the size of the DatePickerSingle
+   * Set the size of the DatePickerRange. Options: 'sm' (small), 'md' (medium)
+   * or 'lg' (large). Default is 'md'.
    */
   bs_size: PropTypes.oneOf(['sm', 'md', 'lg'])
 };

--- a/src/components/input/DatePickerSingle.js
+++ b/src/components/input/DatePickerSingle.js
@@ -289,7 +289,8 @@ DatePickerSingle.propTypes = {
   setProps: PropTypes.func,
 
   /**
-   * Set the size of the DatePickerSingle
+   * Set the size of the DatePickerSingle. Options: 'sm' (small), 'md' (medium)
+   * or 'lg' (large). Default is 'md'.
    */
   bs_size: PropTypes.oneOf(['sm', 'md', 'lg']),
 

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -150,7 +150,7 @@ Input.propTypes = {
   key: PropTypes.string,
 
   /**
-   *
+   * The type of control to render
    */
   type: PropTypes.oneOf([
     // Only allowing the input types with wide browser compatability
@@ -165,20 +165,67 @@ Input.propTypes = {
     'hidden'
   ]),
 
+  /**
+   * The value of the Input
+   */
   value: PropTypes.string,
+
+  /**
+   * The initial size of the control. This value is in pixels unless the value
+   * of the type attribute is text or password, in which case it is an integer
+   * number of characters. This attribute applies only when the type attribute
+   * is set to text, search, tel, url, email, or password, otherwise it is
+   * ignored. In addition, the size must be greater than zero. If you do not
+   * specify a size, a default value of 20 is used.
+   */
   size: PropTypes.string,
+
+  /**
+   * Set the size of the Input. Options: 'sm' (small), 'md' (medium)
+   * or 'lg' (large). Default is 'md'.
+   */
   bs_size: PropTypes.string,
+
+  /**
+   * Apply valid style to the Input for feedback purposes. This will cause
+   * any FormFeedback in the enclosing FormGroup with valid=True to display.
+   */
   valid: PropTypes.bool,
+
+  /**
+   * Apply invalid style to the Input for feedback purposes. This will cause
+   * any FormFeedback in the enclosing FormGroup with valid=False to display.
+   */
   invalid: PropTypes.bool,
+
+  /**
+   * Set to true for a readonly input styled as plain text with the default
+   * form field styling removed and the correct margins and padding preserved.
+   */
   plaintext: PropTypes.bool,
-  addon: PropTypes.bool,
+
+  /**
+   * A hint to the user of what can be entered in the control . The placeholder
+   * text must not contain carriage returns or line-feeds. Note: Do not use the
+   * placeholder attribute instead of a <label> element, their purposes are
+   * different. The <label> attribute describes the role of the form element
+   * (i.e. it indicates what kind of information is expected), and the
+   * placeholder attribute is a hint about the format that the content should
+   * take. There are cases in which the placeholder attribute is never
+   * displayed to the user, so the form must be understandable without it.
+   */
   placeholder: PropTypes.string,
+
+  /**
+   * The name of the control, which is submitted with the form data.
+   */
   name: PropTypes.string,
 
   /**
    * Number of times the `Enter` key was pressed while the input had focus.
    */
   n_submit: PropTypes.number,
+
   /**
    * Last time that `Enter` was pressed.
    */
@@ -188,6 +235,7 @@ Input.propTypes = {
    * Number of times the input lost focus.
    */
   n_blur: PropTypes.number,
+
   /**
    * Last time the input lost focus.
    */

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -38,7 +38,8 @@ InputGroup.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Size of the input group
+   * Set the size of the Input. Options: 'sm' (small), 'md' (medium)
+   * or 'lg' (large). Default is 'md'.
    */
   size: PropTypes.string
 };

--- a/src/components/input/InputGroupAddon.js
+++ b/src/components/input/InputGroupAddon.js
@@ -53,7 +53,7 @@ InputGroupAddon.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Whether to prepend or append the addon.
+   * Whether to prepend or append the addon. Options: 'prepend', or 'append'.
    */
   addon_type: PropTypes.oneOf(['prepend', 'append'])
 };

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -234,12 +234,14 @@ Textarea.propTypes = {
   bs_size: PropTypes.string,
 
   /**
-   * Apply valid style to the Textarea
+   * Apply valid style to the Textarea for feedback purposes. This will cause
+   * any FormFeedback in the enclosing FormGroup with valid=True to display.
    */
   valid: PropTypes.bool,
 
   /**
-   * Apply invalid style to the Textarea
+   * Apply invalid style to the Textarea for feedback purposes. This will cause
+   * any FormFeedback in the enclosing FormGroup with valid=False to display.
    */
   invalid: PropTypes.bool,
 

--- a/src/components/layout/Col.js
+++ b/src/components/layout/Col.js
@@ -76,37 +76,63 @@ Col.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Specify column behaviour on an extra small screen
-   */
-  xs: columnProps,
-
-  /**
-   * Specify column behaviour on a small screen
-   */
-  sm: columnProps,
-
-  /**
-   * Specify column behaviour on a medium screen
-   */
-  md: columnProps,
-
-  /**
-   * Specify column behaviour on a large screen
-   */
-  lg: columnProps,
-
-  /**
-   * Specify column behaviour on an extra large screen
-   */
-  xl: columnProps,
-
-  /**
-   * Specify the width of the column. Is overriden if xs is specified
+   * Specify the width of the column. Behind the scenes this sets behaviour at
+   * the xs breakpoint, and will be overriden if xs is specified.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
    */
   width: columnProps,
 
   /**
-   * Set vertical alignment of this column in row
+   * Specify column behaviour on an extra small screen.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
+   */
+  xs: columnProps,
+
+  /**
+   * Specify column behaviour on a small screen.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
+   */
+  sm: columnProps,
+
+  /**
+   * Specify column behaviour on a medium screen.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
+   */
+  md: columnProps,
+
+  /**
+   * Specify column behaviour on a large screen.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
+   */
+  lg: columnProps,
+
+  /**
+   * Specify column behaviour on an extra large screen.
+   *
+   * Valid arguments are boolean, an integer in the range 1-12 inclusive, or a
+   * dictionary with keys 'offset', 'order', 'size'. See the documentation for
+   * more details.
+   */
+  xl: columnProps,
+
+  /**
+   * Set vertical alignment of this column's content in the parent row. Options
+   * are 'start', 'center', 'end'.
    */
   align: PropTypes.oneOf(['start', 'center', 'end'])
 };

--- a/src/components/layout/Container.js
+++ b/src/components/layout/Container.js
@@ -38,7 +38,9 @@ Container.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Should container be fluid or not
+   * If True the container-fluid class will be applied, and the Container will
+   * expand to fill available space. A non-fluid container resizes responsively
+   * to a fixed width at the different breakpoints.
    */
   fluid: PropTypes.bool,
 

--- a/src/components/layout/Row.js
+++ b/src/components/layout/Row.js
@@ -75,17 +75,20 @@ Row.propTypes = {
   no_gutters: PropTypes.bool,
 
   /**
-   * Set vertical alignment of columns
+   * Set vertical alignment of columns in this row. Options are 'start',
+   * 'center' and 'end'.
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
 
   /**
-   * Set horizontal spacing of columns.
+   * Set horizontal spacing and alignment of columns in this row. Options are
+   * 'start', 'center', 'end', 'around' and 'between'.
    */
   justify: PropTypes.oneOf(['start', 'center', 'end', 'around', 'between']),
 
   /**
-   * For use in forms. Reduces the spacing between columns for a tighter look
+   * For use in forms. When set to True the `form-row` class is applied, which
+   * overrides the default column gutters for a tighter, more compact layout.
    */
   form: PropTypes.bool
 };

--- a/src/components/listgroup/ListGroup.js
+++ b/src/components/listgroup/ListGroup.js
@@ -43,7 +43,9 @@ ListGroup.propTypes = {
   tag: PropTypes.string,
 
   /**
-   * Apply "flush" styling to list
+   * When True the `list-group-flush` class is applied which removes some borders
+   * and rounded corners from the list group in order that they can be rendered
+   * edge-to-edge in the parent container (e.g. a Card).
    */
   flush: PropTypes.bool
 };

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -38,43 +38,44 @@ Nav.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Apply Tab styling to nav items
-   */
-  tabs: PropTypes.bool,
-
-  /**
-   * Apply Pill styling to nav items
+   * Apply pill styling to nav items. Active items will be indicated by a pill.
    */
   pills: PropTypes.bool,
 
   /**
-   * Apply Card styling to nav items
+   * Set to True when using Nav with pills styling inside a CardHeader.
    */
   card: PropTypes.bool,
 
   /**
-   * Expand the nav items to fill the entire space available
+   * Expand the nav items to fill available horizontal space.
    */
   fill: PropTypes.bool,
 
   /**
-   * Expand the nav items to fill the entire space available, making sure
+   * Expand the nav items to fill available horizontal space, making sure
    * every nav item has the same width.
    */
   justified: PropTypes.bool,
 
   /**
-   * Arrange NavItems vertically
+   * Stack NavItems vertically. Set to True for a vertical Nav on all screen
+   * sizes, or pass one of the Bootstrap breakpoints ('xs', 'sm', 'md', 'lg',
+   * 'xl') for a Nav which is vertical at that breakpoint and above, and
+   * horizontal on smaller screens.
    */
   vertical: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
-   * Arrange NavItems horizontally
+   * Specify the horizontal alignment of the NavItems. Options are 'start',
+   * 'center', or 'end'.
    */
-  horizontal: PropTypes.string,
+  horizontal: PropTypes.oneOf(["start", "center", "end"]),
 
   /**
-   * Set to true if using Nav in Navbar component.
+   * Set to True if using Nav in Navbar component. This applies the `navbar-nav`
+   * class to the Nav which uses more lightweight styles to match the parent
+   * Navbar better.
    */
   navbar: PropTypes.bool
 };

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -67,12 +67,14 @@ Navbar.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Apply light styling to the navbar
+   * Applies the `navbar-light` class to the Navbar, causing text in the children
+   * of the Navbar to use dark colors for contrast / visibility.
    */
   light: PropTypes.bool,
 
   /**
-   * Apply dark styling to the navbar
+   * Applies the `navbar-dark` class to the Navbar, causing text in the children
+   * of the Navbar to use light colors for contrast / visibility.
    */
   dark: PropTypes.bool,
 

--- a/src/components/nav/NavbarSimple.js
+++ b/src/components/nav/NavbarSimple.js
@@ -116,17 +116,17 @@ NavbarSimple.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Branding text, to go top left of the navbar
+   * Brand text, to go top left of the navbar.
    */
   brand: PropTypes.string,
 
   /**
-   * Link to attach to brand
+   * Link to attach to brand.
    */
   brand_href: PropTypes.string,
 
   /**
-   * Style options for Brand
+   * CSS style options for brand.
    */
   brand_style: PropTypes.object,
 
@@ -141,22 +141,27 @@ NavbarSimple.propTypes = {
   brand_external_link: PropTypes.bool,
 
   /**
-   * Allow menu items to expand to fill width of page
+   * The contents of the Navbar are wrapped in a container, use fluid=True to
+   * make this container fluid, so that in particular, the contents of the
+   * navbar fill the available horizontal space.
    */
   fluid: PropTypes.bool,
 
   /**
-   * Apply light styling to the navbar
+   * Applies the `navbar-light` class to the NavbarSimple, causing text in the
+   * children of the Navbar to use dark colors for contrast / visibility.
    */
   light: PropTypes.bool,
 
   /**
-   * Apply dark styling to the navbar
+   * Applies the `navbar-dark` class to the NavbarSimple, causing text in the
+   * children of the Navbar to use light colors for contrast / visibility.
    */
   dark: PropTypes.bool,
 
   /**
-   * Fix the navbar's position at the top or bottom of the page, options: top, bottom
+   * Fix the navbar's position at the top or bottom of the page, options: top,
+   * bottom
    */
   fixed: PropTypes.string,
 
@@ -179,7 +184,9 @@ NavbarSimple.propTypes = {
   color: PropTypes.string,
 
   /**
-   * Specify screen size at which to expand the menu bar, e.g. sm, md, lg etc.
+   * Specify breakpoint at which to expand the menu bar. Options are: 'xs',
+   * 'sm', 'md', 'lg', or 'xl'. Below this breakpoint the navbar will collapse
+   * and navitems will be placed in a togglable collapse element.
    */
   expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -36,7 +36,7 @@ Tab.propTypes = {
   key: PropTypes.string,
 
   /**
-   * The tab's label
+   * The tab's label, displayed in the tab itself.
    */
   label: PropTypes.string,
 

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -136,7 +136,7 @@ Tabs.propTypes = {
   active_tab: PropTypes.string,
 
   /**
-   * Set to True to use the card header style for tabs.
+   * Set to True if using tabs inside a CardHeader.
    */
   card: PropTypes.bool
 };


### PR DESCRIPTION
This PR expands and makes consistent many of the existing docstrings and adds documentation to props that were previously undocumented.

While working on this I realised that the `FormFeedback` example in the docs was overcomplicated, and simplified it. I also noticed that the `disabled` prop of `FormGroup`, the `tabs` prop of `Nav` and `inline` prop of `FormText` serve no useful purpose so I removed them.